### PR TITLE
[PIL-1171] Do not accept additional field for amend subscription endpoint

### DIFF
--- a/app/uk/gov/hmrc/pillar2stubs/models/AmendSubscription.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/AmendSubscription.scala
@@ -54,7 +54,14 @@ case class AmendSubscriptionSuccess(
 )
 
 object AmendSubscriptionSuccess {
-  implicit val format: OFormat[AmendSubscriptionSuccess] = Json.format[AmendSubscriptionSuccess]
+
+  implicit val reads: Reads[AmendSubscriptionSuccess] = Reads { js =>
+    if (js.asInstanceOf[JsObject].value.contains("replaceFilingMember"))
+      JsError("AdditionalProperty")
+    else JsSuccess(js)
+  }.andThen(Json.reads[AmendSubscriptionSuccess])
+
+  implicit val format: OFormat[AmendSubscriptionSuccess] = OFormat(reads, Json.writes[AmendSubscriptionSuccess])
 }
 
 case class AmendSubscriptionResponse(value: AmendSubscriptionSuccess)


### PR DESCRIPTION
Add custom logic to verify that `replaceFilingMember` field is not included in AmendSubscription payload.

This is a really custom fix that must be superseded by a longer term change to reject all additionFields for all ETMP endpoints. This is short term because we have an incident to fix and resolve