### PR TITLE
PIL-1348 Align stub for BTN submit with EPID1519 "successResponseExample".

### DIFF
--- a/app/uk/gov/hmrc/pillar2stubs/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/BTNController.scala
@@ -38,7 +38,7 @@ class BTNController @Inject() (cc: ControllerComponents, authFilter: AuthActionF
       case "XEPLR4220000000" => UnprocessableEntity(Json.toJson(BTNFailureResponsePayload(BTNFailure(now, "094", "Invalid DTT Election"))))
       case "XEPLR4000000000" => BadRequest(Json.toJson(BTNErrorResponse(BTNError("400", "Request could not be processed"))))
       case "XEPLR5000000000" => InternalServerError(Json.toJson(BTNErrorResponse(BTNError("500", "Error in downstream system"))))
-      case _                 => Created(Json.toJson(BTNSuccessResponsePayload(BTNSuccess(now, "11223344556677", "XTC01234123412"))))
+      case _                 => Created(Json.toJson(BTNSuccessResponsePayload(BTNSuccess(now))))
     }
   }
 

--- a/app/uk/gov/hmrc/pillar2stubs/models/btn/BTNSuccess.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/btn/BTNSuccess.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.ZonedDateTime
 
-case class BTNSuccess(processingDate: ZonedDateTime, formBundleNumber: String, chargeReference: String)
+case class BTNSuccess(processingDate: ZonedDateTime)
 
 object BTNSuccess {
   implicit val format: OFormat[BTNSuccess] = Json.format[BTNSuccess]


### PR DESCRIPTION
PIL-1348 Align stub for BTN submit with EPID1519 "successResponseExample".
Remove formBundleNumber & chargeReference from BTNSuccess response, 
to Align the stub for BTN submit with EPID1519 : 

      "successResponseExample": {
        "summary": "Example of successful response",
        "description": "Example of successful response",
        "value": {
          "success": {
            "processingDate": "2022-01-31T09:26:17Z"
          }
        }
