### PR TITLE
PIL-1770: Submit/Amend UKTR - optional chargeReference

### DIFF
--- a/app/uk/gov/hmrc/pillar2stubs/controllers/UKTRAmendController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/UKTRAmendController.scala
@@ -20,6 +20,7 @@ import play.api.Logging
 import play.api.libs.json._
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.pillar2stubs.controllers.actions.AuthActionFilter
+import uk.gov.hmrc.pillar2stubs.models.UKTRSubmissionResponse.{successfulLiabilityResponse, successfulNilResponse}
 import uk.gov.hmrc.pillar2stubs.models.{UKTRSubmission, UKTRSubmissionData, UKTRSubmissionNilReturn}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -126,19 +127,11 @@ class UKTRAmendController @Inject() (
                         )
                       } else {
                         logger.info("Returning success response for liability amendment")
-                        Future.successful(
-                          Ok(
-                            successfulResponse
-                          )
-                        )
+                        Future.successful(Ok(successfulLiabilityResponse))
                       }
                     case UKTRSubmissionNilReturn(_, _, _, _, _) =>
                       logger.info("Returning success response for Nil return amendment")
-                      Future.successful(
-                        Ok(
-                          successfulResponse
-                        )
-                      )
+                      Future.successful(Ok(successfulNilResponse))
                   }
                 }
 
@@ -158,13 +151,4 @@ class UKTRAmendController @Inject() (
         }
     }
   }
-
-  private def successfulResponse(implicit clock: Clock): JsObject = Json.obj(
-    "success" -> Json
-      .obj(
-        "processingDate"   -> ZonedDateTime.now(clock).format(DateTimeFormatter.ISO_INSTANT),
-        "formBundleNumber" -> "119000004320",
-        "chargeReference"  -> "XTC01234123412"
-      )
-  )
 }

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/UKTRSubmitController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/UKTRSubmitController.scala
@@ -20,6 +20,7 @@ import play.api.Logging
 import play.api.libs.json._
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.pillar2stubs.controllers.actions.AuthActionFilter
+import uk.gov.hmrc.pillar2stubs.models.UKTRSubmissionResponse.{successfulLiabilityResponse, successfulNilResponse}
 import uk.gov.hmrc.pillar2stubs.models.{UKTRSubmission, UKTRSubmissionData, UKTRSubmissionNilReturn}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -77,19 +78,11 @@ class UKTRSubmitController @Inject() (
                     )
                   } else {
                     logger.info("Returning success response for liability request")
-                    Future.successful(
-                      Created(
-                        successfulResponse
-                      )
-                    )
+                    Future.successful(Created(successfulLiabilityResponse))
                   }
                 case UKTRSubmissionNilReturn(_, _, _, _, _) =>
                   logger.info("Returning success response for Nil return request")
-                  Future.successful(
-                    Created(
-                      successfulResponse
-                    )
-                  )
+                  Future.successful(Created(successfulNilResponse))
               }
             }
 
@@ -108,12 +101,4 @@ class UKTRSubmitController @Inject() (
         Future.successful(BadRequest(Json.obj("error" -> "Invalid JSON data")).as("application/json"))
     }
   }
-  private def successfulResponse(implicit clock: Clock): JsObject = Json.obj(
-    "success" -> Json
-      .obj(
-        "processingDate"   -> ZonedDateTime.now(clock).format(DateTimeFormatter.ISO_INSTANT),
-        "formBundleNumber" -> "119000004320",
-        "chargeReference"  -> "XTC01234123412"
-      )
-  )
 }

--- a/app/uk/gov/hmrc/pillar2stubs/models/UKTRSubmissionResponse.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/UKTRSubmissionResponse.scala
@@ -16,23 +16,25 @@
 
 package uk.gov.hmrc.pillar2stubs.models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{JsObject, Json, OFormat}
 
-import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.{Clock, LocalDateTime, ZonedDateTime}
 
-case class UKTRSubmissionResponse(
-  success: UKTRSubmissionSuccess
-)
+case class UKTRSubmissionResponse(success: UKTRSubmissionSuccess)
 
 object UKTRSubmissionResponse {
   implicit val format: OFormat[UKTRSubmissionResponse] = Json.format[UKTRSubmissionResponse]
+
+  def successfulLiabilityResponse(implicit clock: Clock): JsObject =
+    successfulNilResponse.deepMerge(Json.obj("success" -> Json.obj("chargeReference" -> "XTC01234123412")))
+
+  def successfulNilResponse(implicit clock: Clock): JsObject = Json.obj(
+    "success" -> Json.obj("processingDate" -> ZonedDateTime.now(clock).format(DateTimeFormatter.ISO_INSTANT), "formBundleNumber" -> "119000004320")
+  )
 }
 
-case class UKTRSubmissionSuccess(
-  processingDate:   LocalDateTime,
-  formBundleNumber: String,
-  chargeReference:  Option[String]
-)
+case class UKTRSubmissionSuccess(processingDate: LocalDateTime, formBundleNumber: String, chargeReference: Option[String])
 
 object UKTRSubmissionSuccess {
   implicit val format: OFormat[UKTRSubmissionSuccess] = Json.format[UKTRSubmissionSuccess]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,11 +69,6 @@ metrics {
 
 # Microservice specific config
 
-auditing {
-  enabled = false
-}
-
-
 microservice {
   services {
     auth {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.6.0"
+  private val bootstrapVersion = "9.9.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"   %% "bootstrap-backend-play-30" % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.11")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/UKTRAmendControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/UKTRAmendControllerSpec.scala
@@ -113,7 +113,6 @@ class UKTRAmendControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       status(result) mustBe OK
       val jsonResult = contentAsJson(result)
       (jsonResult \ "success" \ "formBundleNumber").as[String] mustEqual "119000004320"
-      (jsonResult \ "success" \ "chargeReference").as[String] mustEqual "XTC01234123412"
       (jsonResult \ "success" \ "processingDate").as[ZonedDateTime] mustEqual ZonedDateTime.now(cogsworth)
     }
 

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/UKTRSubmitControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/UKTRSubmitControllerSpec.scala
@@ -109,7 +109,6 @@ class UKTRSubmitControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       status(result) mustBe CREATED
       val jsonResult = contentAsJson(result)
       (jsonResult \ "success" \ "formBundleNumber").as[String] mustEqual "119000004320"
-      (jsonResult \ "success" \ "chargeReference").as[String] mustEqual "XTC01234123412"
       (jsonResult \ "success" \ "processingDate").as[ZonedDateTime] mustEqual ZonedDateTime.now(cogsworth)
     }
 


### PR DESCRIPTION
Make response field `chargeReference` optional to accommodate both _Liability_ and _Nil_ returns.