### PR TITLE
[PIL-2047-hip-errors] Adjust HIP errors

### DIFF
--- a/app/uk/gov/hmrc/pillar2stubs/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/BTNController.scala
@@ -21,6 +21,8 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.pillar2stubs.controllers.actions.AuthActionFilter
 import uk.gov.hmrc.pillar2stubs.models.btn._
+import uk.gov.hmrc.pillar2stubs.models.error.{HIPError, HIPErrorWrapper, HIPFailure}
+import uk.gov.hmrc.pillar2stubs.models.error.Origin.HIP
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.temporal.ChronoUnit
@@ -36,7 +38,7 @@ class BTNController @Inject() (cc: ControllerComponents, authFilter: AuthActionF
   def submitBTN: Action[BTNRequest] = (Action(parse.json[BTNRequest]) andThen authFilter andThen etmpHeaderFilter) { implicit request =>
     request.headers.get("X-PILLAR2-ID").get match {
       case "XEPLR4220000000" => UnprocessableEntity(Json.toJson(BTNFailureResponsePayload(BTNFailure(now, "094", "Invalid DTT Election"))))
-      case "XEPLR4000000000" => BadRequest(Json.toJson(BTNErrorResponse(BTNError("400", "Request could not be processed"))))
+      case "XEPLR4000000000" => BadRequest(Json.toJson(HIPErrorWrapper(HIP, HIPFailure(List(HIPError("invalid json", "invalid json"))))))
       case "XEPLR5000000000" => InternalServerError(Json.toJson(BTNErrorResponse(BTNError("500", "Error in downstream system"))))
       case _                 => Created(Json.toJson(BTNSuccessResponsePayload(BTNSuccess(now))))
     }

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/ObligationAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/ObligationAndSubmissionsController.scala
@@ -21,6 +21,8 @@ import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.pillar2stubs.controllers.actions.AuthActionFilter
+import uk.gov.hmrc.pillar2stubs.models.error.{HIPError, HIPErrorWrapper, HIPFailure}
+import uk.gov.hmrc.pillar2stubs.models.error.Origin.{HIP, HoD}
 import uk.gov.hmrc.pillar2stubs.models.obligationsandsubmissions.ObligationsAndSubmissionsErrorCodes._
 import uk.gov.hmrc.pillar2stubs.models.obligationsandsubmissions._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -49,7 +51,7 @@ class ObligationAndSubmissionsController @Inject() (cc: ControllerComponents, au
             UnprocessableEntity(Json.toJson(ObligationsAndSubmissionsDetailedErrorResponse(REQUEST_COULD_NOT_BE_PROCESSED_003)))
           case "XEPLR0400000422" => UnprocessableEntity(Json.toJson(ObligationsAndSubmissionsDetailedErrorResponse(DUPLICATE_SUBMISSION_004)))
           case "XEPLR2500000422" => UnprocessableEntity(Json.toJson(ObligationsAndSubmissionsDetailedErrorResponse(NO_DATA_FOUND_025)))
-          case "XEPLR0000000400" => BadRequest(Json.toJson(ObligationsAndSubmissionsSimpleErrorResponse.InvalidJsonError()))
+          case "XEPLR0000000400" => BadRequest(Json.toJson(HIPErrorWrapper(HIP, HIPFailure(List(HIPError("invalid json", "invalid json"))))))
           case "XEPLR0000000500" => InternalServerError(Json.toJson(ObligationsAndSubmissionsSimpleErrorResponse.SAPError))
           case "XEPLR1111111111" => Ok(Json.toJson(ObligationsAndSubmissionsSuccessResponse.withMultipleAccountingPeriods()))
           case "XEPLR2222222222" => Ok(Json.toJson(ObligationsAndSubmissionsSuccessResponse.withNoAccountingPeriods()))
@@ -61,7 +63,9 @@ class ObligationAndSubmissionsController @Inject() (cc: ControllerComponents, au
         }
       }
     }.recover { case e: Throwable =>
-      BadRequest(Json.toJson(ObligationsAndSubmissionsSimpleErrorResponse.InvalidJsonError(s"Errors parsing date: ${e.getMessage}")))
+      BadRequest(
+        Json.toJson(HIPErrorWrapper(HoD, ObligationsAndSubmissionsSimpleErrorResponse.InvalidJsonError(s"Errors parsing date: ${e.getMessage}")))
+      )
     }.get
   }
 }

--- a/app/uk/gov/hmrc/pillar2stubs/models/error/HIPErrorWrapper.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/error/HIPErrorWrapper.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2stubs.models.error
+
+import enumeratum._
+import play.api.libs.json._
+
+case class HIPErrorWrapper[T](origin: Origin, response: T)
+
+object HIPErrorWrapper {
+
+  implicit def format[T: OFormat]: OFormat[HIPErrorWrapper[T]] = new OFormat[HIPErrorWrapper[T]] {
+    override def reads(json: JsValue): JsResult[HIPErrorWrapper[T]] =
+      for {
+        origin   <- (json \ "origin").validate[Origin]
+        response <- (json \ "response").validate[T]
+      } yield HIPErrorWrapper(origin, response)
+
+    override def writes(obj: HIPErrorWrapper[T]): JsObject = Json.obj("origin" -> obj.origin, "response" -> obj.response)
+  }
+}
+
+case class HIPFailure(failures: List[HIPError])
+
+object HIPFailure {
+  implicit val format: OFormat[HIPFailure] = Json.format
+}
+
+case class HIPError(reason: String, `type`: String)
+
+object HIPError {
+  implicit val format: OFormat[HIPError] = Json.format
+}
+
+sealed trait Origin extends EnumEntry
+
+object Origin extends Enum[Origin] with PlayJsonEnum[Origin] {
+  val values = findValues
+
+  case object HIP extends Origin
+  case object HoD extends Origin
+}

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/BTNControllerSpec.scala
@@ -26,6 +26,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderNames
 import uk.gov.hmrc.pillar2stubs.models.btn._
+import uk.gov.hmrc.pillar2stubs.models.error.{HIPErrorWrapper, HIPFailure}
+import uk.gov.hmrc.pillar2stubs.models.error.Origin.HIP
 
 import java.time.LocalDate
 import scala.util.Random
@@ -62,8 +64,10 @@ class BTNControllerSpec extends AnyFunSuite with Matchers with GuiceOneAppPerSui
     val result = route(app, request).value
 
     status(result) shouldEqual 400
-    contentAsJson(result).validate[BTNErrorResponse].asEither.isRight shouldBe true
-    contentAsJson(result).as[BTNErrorResponse].error.code shouldEqual "400"
+    val response = contentAsJson(result).as[HIPErrorWrapper[HIPFailure]]
+    response.response.failures should have size 1
+    response.response.failures.head.reason shouldEqual "invalid json"
+    response.origin shouldEqual HIP
   }
 
   test("InternalServerError BTN submission") {

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -24,6 +24,8 @@ import play.api.mvc.{AnyContentAsEmpty, Headers}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderNames
+import uk.gov.hmrc.pillar2stubs.models.error.Origin.HIP
+import uk.gov.hmrc.pillar2stubs.models.error.{HIPErrorWrapper, HIPFailure}
 import uk.gov.hmrc.pillar2stubs.models.obligationsandsubmissions._
 
 import scala.util.Random
@@ -237,8 +239,10 @@ class ObligationsAndSubmissionsControllerSpec extends AnyFunSuite with Matchers 
     val result = route(app, request).value
 
     status(result) shouldEqual 400
-    contentAsJson(result).validate[ObligationsAndSubmissionsSimpleErrorResponse].asEither.isRight shouldBe true
-    contentAsJson(result).as[ObligationsAndSubmissionsSimpleErrorResponse].error.code shouldEqual "400"
+    val response = contentAsJson(result).as[HIPErrorWrapper[HIPFailure]]
+    response.response.failures should have size 1
+    response.response.failures.head.reason shouldEqual "invalid json"
+    response.origin shouldEqual HIP
   }
 
   test("InternalServerError ObligationsAndSubmissions submission") {


### PR DESCRIPTION
Adjust errors for all HIP endpoints. HIP wraps 400 BadRequest errors with an origin and will largely be used for invalid JSON error responses