### PR TITLE
PIL-2105: Add async subscription processing timeout test scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,31 @@ Retrieves the Subscription details for the specific plrReference
 | XEPLR1066196600 | 200         | OK                    | Returns read success response with domesticOnly set to true.        |
 | XEPLR__________ | 200         | OK                    | Returns read success response .                                        |
 
+#### **🎯 PIL-2105: Async Processing Timeout Test Scenarios**
+
+The following PLR References are specifically designed to test the asynchronous subscription processing timeout logic implemented in PIL-2105:
+
+| plrReference     | Delay   | Status Code | Status                | Description                                                                    |
+|------------------|---------|-------------|-----------------------|--------------------------------------------------------------------------------|
+| XEPLR0000000003  | 3s      | 200         | OK                    | Returns success response after a 3-second delay (tests initial retry logic). |
+| XEPLR0000000006  | 6s      | 200         | OK                    | Returns success response after a 6-second delay (tests mid-range timing).    |
+| XEPLR0000000010  | 10s     | 200         | OK                    | Returns success response after a 10-second delay (tests extended timing).    |
+| XEPLR0000000015  | 15s     | 200         | OK                    | Returns success response after a 15-second delay (tests near-timeout).       |
+| XEPLR0000000025  | 25s     | 200         | OK                    | Returns success response after a 25-second delay (tests timeout scenario).   |
+| XEPLRPROCESSING  | N/A     | 422         | CANNOT_COMPLETE_REQUEST | Always returns processing error to simulate ongoing subscription processing.   |
+
+**Testing Progressive Timeout Logic:**
+- **Frontend behavior**: Progressive retry intervals (3s → 6s → 9s → 15s → 20s timeout)
+- **Use XEPLRPROCESSING**: To test continuous retry attempts until 20-second timeout
+- **Use timed scenarios**: To test success at different stages of the retry process
+- **Expected outcome**: After 20 seconds, frontend should redirect to "Registration in Progress" page
+
+**Example Test Flow:**
+1. Start subscription with `XEPLRPROCESSING` PLR Reference
+2. Frontend polls every 3 seconds for first 9 seconds (gets 422 errors)
+3. Frontend polls every 5 seconds from 10-20 seconds (gets 422 errors)
+4. At 20 seconds: Frontend times out and redirects to Registration in Progress page
+
 #### Happy Path:
 
 To trigger the happy path, ensure you provide a valid plrReference

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -90,9 +90,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         case "XEPLR0123456503" =>
           Future.successful(ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get))
         
-        // New async processing timeout test scenarios for PIL-2105
         case "XEPLR0000000003" =>
-          // Simulate 3-second processing delay
           Thread.sleep(3000)
           Future.successful(
             Ok(
@@ -103,7 +101,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
           
         case "XEPLR0000000006" =>
-          // Simulate 6-second processing delay
           Thread.sleep(6000)
           Future.successful(
             Ok(
@@ -114,7 +111,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
           
         case "XEPLR0000000010" =>
-          // Simulate 10-second processing delay
           Thread.sleep(10000)
           Future.successful(
             Ok(
@@ -125,7 +121,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
           
         case "XEPLR0000000015" =>
-          // Simulate 15-second processing delay
           Thread.sleep(15000)
           Future.successful(
             Ok(
@@ -136,7 +131,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
           
         case "XEPLR0000000025" =>
-          // Simulate 25-second processing delay (timeout scenario)
           Thread.sleep(25000)
           Future.successful(
             Ok(
@@ -147,7 +141,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
           
         case "XEPLRPROCESSING" =>
-          // Always return 422 to simulate ongoing processing
           Future.successful(UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get))
           
         case "XEPLR5555555555" =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -89,6 +89,67 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
         case "XEPLR0123456503" =>
           Future.successful(ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get))
+        
+        // New async processing timeout test scenarios for PIL-2105
+        case "XEPLR0000000003" =>
+          // Simulate 3-second processing delay
+          Thread.sleep(3000)
+          Future.successful(
+            Ok(
+              resourceAsString("/resources/subscription/ReadSuccessResponse.json")
+                .map(replacePillar2Id(_, plrReference))
+                .get
+            )
+          )
+          
+        case "XEPLR0000000006" =>
+          // Simulate 6-second processing delay
+          Thread.sleep(6000)
+          Future.successful(
+            Ok(
+              resourceAsString("/resources/subscription/ReadSuccessResponse.json")
+                .map(replacePillar2Id(_, plrReference))
+                .get
+            )
+          )
+          
+        case "XEPLR0000000010" =>
+          // Simulate 10-second processing delay
+          Thread.sleep(10000)
+          Future.successful(
+            Ok(
+              resourceAsString("/resources/subscription/ReadSuccessResponse.json")
+                .map(replacePillar2Id(_, plrReference))
+                .get
+            )
+          )
+          
+        case "XEPLR0000000015" =>
+          // Simulate 15-second processing delay
+          Thread.sleep(15000)
+          Future.successful(
+            Ok(
+              resourceAsString("/resources/subscription/ReadSuccessResponse.json")
+                .map(replacePillar2Id(_, plrReference))
+                .get
+            )
+          )
+          
+        case "XEPLR0000000025" =>
+          // Simulate 25-second processing delay (timeout scenario)
+          Thread.sleep(25000)
+          Future.successful(
+            Ok(
+              resourceAsString("/resources/subscription/ReadSuccessResponse.json")
+                .map(replacePillar2Id(_, plrReference))
+                .get
+            )
+          )
+          
+        case "XEPLRPROCESSING" =>
+          // Always return 422 to simulate ongoing processing
+          Future.successful(UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get))
+          
         case "XEPLR5555555555" =>
           Future.successful(
             Ok(

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -91,7 +91,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           Future.successful(ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get))
 
         case "XEPLR0000000003" =>
-          Thread.sleep(3000)
           Future.successful(
             Ok(
               resourceAsString("/resources/subscription/ReadSuccessResponse.json")
@@ -101,7 +100,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
 
         case "XEPLR0000000006" =>
-          Thread.sleep(6000)
           Future.successful(
             Ok(
               resourceAsString("/resources/subscription/ReadSuccessResponse.json")
@@ -111,7 +109,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
 
         case "XEPLR0000000010" =>
-          Thread.sleep(10000)
           Future.successful(
             Ok(
               resourceAsString("/resources/subscription/ReadSuccessResponse.json")
@@ -121,7 +118,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
 
         case "XEPLR0000000015" =>
-          Thread.sleep(15000)
           Future.successful(
             Ok(
               resourceAsString("/resources/subscription/ReadSuccessResponse.json")
@@ -131,7 +127,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           )
 
         case "XEPLR0000000025" =>
-          Thread.sleep(25000)
           Future.successful(
             Ok(
               resourceAsString("/resources/subscription/ReadSuccessResponse.json")
@@ -218,11 +213,9 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Future.successful(ServiceUnavailable(resourceAsString("/resources/error/ServiceUnavailable.json").getOrElse("Service unavailable error")))
 
           case "timeout" =>
-            Thread.sleep(30000)
             Future.successful(Ok(resourceAsString("/resources/subscription/AmendSuccessResponse.json").getOrElse("Success response")))
 
           case "10 seconds" =>
-            Thread.sleep(10000)
             Future.successful(Ok(resourceAsString("/resources/subscription/AmendSuccessResponse.json").getOrElse("Success response")))
 
           case _ =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -40,6 +40,21 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         val safeId           = input.safeId
 
         (organisationName, safeId) match {
+          // PIL-2105: Test scenarios for Registration in Progress functionality
+          case ("XEPLRPROCESSING", _) =>
+            UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get)
+          case ("XEPLR0000000003", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
+          case ("XEPLR0000000006", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000006")).get)
+          case ("XEPLR0000000010", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000010")).get)
+          case ("XEPLR0000000015", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000015")).get)
+          case ("XEPLR0000000025", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000025")).get)
+
+          // Existing error test scenarios
           case ("duplicateSub", _) =>
             Conflict(resourceAsString("/resources/error/subscription/Conflict.json").get)
           case ("unprocessableSub", _) =>
@@ -53,6 +68,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           case ("subInvalidRequest", _) =>
             BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
 
+          // Existing safeId-based scenarios
           case ("XE0000123456400", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456400")).get)
           case ("XE0000123456404", _) =>
@@ -67,6 +83,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345671")).get)
           case ("XMPLR0009999999", _) =>
             Conflict(resourceAsString("/resources/error/subscription/Conflict.json").map(replacePillar2Id(_, "XMPLR0009999999")).get)
+          // Default case
           case (_, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345674")).get)
           case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -89,7 +89,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
         case "XEPLR0123456503" =>
           Future.successful(ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get))
-        
+
         case "XEPLR0000000003" =>
           Thread.sleep(3000)
           Future.successful(
@@ -99,7 +99,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
                 .get
             )
           )
-          
+
         case "XEPLR0000000006" =>
           Thread.sleep(6000)
           Future.successful(
@@ -109,7 +109,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
                 .get
             )
           )
-          
+
         case "XEPLR0000000010" =>
           Thread.sleep(10000)
           Future.successful(
@@ -119,7 +119,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
                 .get
             )
           )
-          
+
         case "XEPLR0000000015" =>
           Thread.sleep(15000)
           Future.successful(
@@ -129,7 +129,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
                 .get
             )
           )
-          
+
         case "XEPLR0000000025" =>
           Thread.sleep(25000)
           Future.successful(
@@ -139,10 +139,10 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
                 .get
             )
           )
-          
+
         case "XEPLRPROCESSING" =>
           Future.successful(UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get))
-          
+
         case "XEPLR5555555555" =>
           Future.successful(
             Ok(

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -34,78 +34,79 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
   def createSubscription: Action[JsValue] = (Action(parse.json) andThen authFilter) { implicit request =>
     logger.info(s"Subscription Request received \n ${request.body} \n")
 
-    // PIL-2105: Check session cookies for test scenarios first
-    val sessionCookie = request.cookies.get("mdtp").orElse(request.cookies.get("pillar2-frontend-session"))
-    val sessionId     = sessionCookie.map(_.value).getOrElse("")
+    // PIL-2105: Extract primary contact name from JSON for test scenarios
+    val primaryContactName = (request.body \ "primaryContactDetails" \ "name").asOpt[String].getOrElse("")
 
-    if (sessionId.contains("XEPLRPROCESSING")) {
-      UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get)
-    } else if (sessionId.contains("XEPLR0000000025")) {
-      Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000025")).get)
-    } else if (sessionId.contains("XEPLR0000000015")) {
-      Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000015")).get)
-    } else if (sessionId.contains("XEPLR0000000010")) {
-      Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000010")).get)
-    } else if (sessionId.contains("XEPLR0000000006")) {
-      Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000006")).get)
-    } else if (sessionId.contains("XEPLR0000000003")) {
-      Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
-    } else {
-      // Fall back to existing logic
-      request.body.asOpt[Subscription] match {
-        case Some(input) =>
-          val organisationName = input.organisationName
-          val safeId           = input.safeId
+    // Check primary contact name for PIL-2105 test scenarios first
+    primaryContactName match {
+      case name if name.contains("XEPLRPROCESSING") =>
+        UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get)
+      case name if name.contains("XEPLR0000000025") =>
+        Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000025")).get)
+      case name if name.contains("XEPLR0000000015") =>
+        Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000015")).get)
+      case name if name.contains("XEPLR0000000010") =>
+        Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000010")).get)
+      case name if name.contains("XEPLR0000000006") =>
+        Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000006")).get)
+      case name if name.contains("XEPLR0000000003") =>
+        Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
+      case _ =>
+        // Fall back to existing organization name logic
+        request.body.asOpt[Subscription] match {
+          case Some(input) =>
+            val organisationName = input.organisationName
+            val safeId           = input.safeId
 
-          (organisationName, safeId) match {
-            // PIL-2105: Test scenarios for Registration in Progress functionality
-            case ("XEPLRPROCESSING", _) =>
-              UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get)
-            case ("XEPLR0000000003", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
-            case ("XEPLR0000000006", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000006")).get)
-            case ("XEPLR0000000010", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000010")).get)
-            case ("XEPLR0000000015", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000015")).get)
-            case ("XEPLR0000000025", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000025")).get)
+            (organisationName, safeId) match {
+              // PIL-2105: Test scenarios for Registration in Progress functionality
+              case ("XEPLRPROCESSING", _) =>
+                UnprocessableEntity(resourceAsString("/resources/subscription/ProcessingResponse.json").get)
+              case ("XEPLR0000000003", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
+              case ("XEPLR0000000006", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000006")).get)
+              case ("XEPLR0000000010", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000010")).get)
+              case ("XEPLR0000000015", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000015")).get)
+              case ("XEPLR0000000025", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000025")).get)
 
-            // Existing error test scenarios
-            case ("duplicateSub", _) =>
-              Conflict(resourceAsString("/resources/error/subscription/Conflict.json").get)
-            case ("unprocessableSub", _) =>
-              UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
-            case ("subServerError", _) =>
-              ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get)
-            case ("subRecordNotFound", _) =>
-              NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get)
-            case ("subReqNotProcessed", _) =>
-              UnprocessableEntity(resourceAsString("/resources/error/subscription/UnprocessableEntity.json").get)
-            case ("subInvalidRequest", _) =>
-              BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
+              // Existing error test scenarios
+              case ("duplicateSub", _) =>
+                Conflict(resourceAsString("/resources/error/subscription/Conflict.json").get)
+              case ("unprocessableSub", _) =>
+                UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
+              case ("subServerError", _) =>
+                ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get)
+              case ("subRecordNotFound", _) =>
+                NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get)
+              case ("subReqNotProcessed", _) =>
+                UnprocessableEntity(resourceAsString("/resources/error/subscription/UnprocessableEntity.json").get)
+              case ("subInvalidRequest", _) =>
+                BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
 
-            case ("XE0000123456400", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456400")).get)
-            case ("XE0000123456404", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456404")).get)
-            case ("XE0000123456422", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456422")).get)
-            case ("XE0000123456500", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456500")).get)
-            case ("XE0000123456503", _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456503")).get)
-            case (_, "XE0000123456789") =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345671")).get)
-            case ("XMPLR0009999999", _) =>
-              Conflict(resourceAsString("/resources/error/subscription/Conflict.json").map(replacePillar2Id(_, "XMPLR0009999999")).get)
-            case (_, _) =>
-              Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345674")).get)
-            case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
-          }
-        case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
-      }
+              case ("XE0000123456400", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456400")).get)
+              case ("XE0000123456404", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456404")).get)
+              case ("XE0000123456422", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456422")).get)
+              case ("XE0000123456500", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456500")).get)
+              case ("XE0000123456503", _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456503")).get)
+              case (_, "XE0000123456789") =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345671")).get)
+              case ("XMPLR0009999999", _) =>
+                Conflict(resourceAsString("/resources/error/subscription/Conflict.json").map(replacePillar2Id(_, "XMPLR0009999999")).get)
+              case (_, _) =>
+                Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345674")).get)
+              case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
+            }
+          case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
+        }
     }
   }
 

--- a/conf/resources/subscription/ProcessingResponse.json
+++ b/conf/resources/subscription/ProcessingResponse.json
@@ -1,0 +1,14 @@
+{
+  "errors": {
+    "timestamp": "2024-01-31T09:26:17Z",
+    "correlationId": "c182e731-2386-4359-8ee6-f911d6e5f4bc",
+    "errorCode": "422",
+    "errorMessage": "Request could not be completed because the subscription is being processed",
+    "source": "Back End",
+    "sourceFaultDetail": {
+      "detail": [
+        "Subscription processing in progress - please retry in a few seconds"
+      ]
+    }
+  }
+} 


### PR DESCRIPTION
Add comprehensive test scenarios for async subscription processing timeout logic. Includes 6 new PLR reference test cases with progressive delays and continuous processing scenarios. Supports frontend timeout testing with 3s-6s-9s-15s-20s intervals.