### PR TITLE
PIL-2105: Updated README and SubscriptionController

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,15 @@ Creates a Subscription request
 
 #### Registration In Progress Test Data
 
-For testing the registration in progress feature, use specific organisation names to trigger different polling behaviors:
+For testing the registration in progress feature, use specific organisation names OR UPE contact names to trigger different polling behaviors:
 
-| Organisation Name      | PLR Reference Returned | Polling Behavior                                                        |
-|------------------------|------------------------|-------------------------------------------------------------------------|
-| Quick Processing Corp  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
-| Medium Processing Corp | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
-| Timeout Processing Corp| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
+| Test Trigger                           | PLR Reference Returned | Polling Behavior                                                        |
+|----------------------------------------|------------------------|-------------------------------------------------------------------------|
+| Organisation Name: "Quick Processing Corp" OR UPE Contact Name: "Quick Processing"  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
+| Organisation Name: "Medium Processing Corp" OR UPE Contact Name: "Medium Processing" | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
+| Organisation Name: "Timeout Processing Corp" OR UPE Contact Name: "Timeout Processing"| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
+
+**Note**: The UPE contact name is read from `primaryContactDetails.name` in the request body. If both organisation name and UPE contact name match test triggers, UPE contact name takes precedence.
 
 #### Happy Path:
 
@@ -548,6 +550,34 @@ HTTP 404 Record Not Found Error
 > Response status: 404
 >
 > Response body: N/A
+---
+
+```
+GET /pillar2/subscription/read-subscription/:id/:plrReference
+```
+
+Reads the Subscription details and caches them for the specific PLR reference and ID. This endpoint is used by the DashboardController for testing registration in progress scenarios.
+
+| plrReference    | Status Code | Status                | Description                                                                                          |
+|-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
+| XEPLR0000000001 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 3 polls, then 200 success                     |
+| XEPLR0000000002 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 8 polls, then 200 success                     |
+| XEPLR0000000003 | 500         | INTERNAL_SERVER_ERROR | Registration in progress test - Always returns 500 (timeout scenario)                              |
+| Any other PLR   | 200         | OK                    | Returns read success response for any other valid PLR reference                                      |
+
+#### Happy Path:
+
+To trigger the happy path, provide a valid `id` and `plrReference`.
+
+The response format is identical to the `GET /pillar2/subscription/:plrReference` endpoint.
+
+#### Registration In Progress Testing:
+
+This endpoint uses the same polling logic as the `retrieveSubscription` endpoint for the special test PLR references:
+- **XEPLR0000000001**: Quick processing scenario - succeeds after 3 attempts
+- **XEPLR0000000002**: Medium processing scenario - succeeds after 8 attempts  
+- **XEPLR0000000003**: Timeout scenario - always returns server error
+
 ---
 
 ```

--- a/README.md
+++ b/README.md
@@ -239,26 +239,13 @@ Creates a Subscription request
 
 #### Registration In Progress Test Data
 
-For testing the registration in progress feature, you can use either UPE contact names or organisation names to trigger different polling behaviors:
-
-**Option 1: Using UPE Contact Name**
-
-Enter one of these values in the "Contact Name" field during registration:
-
-| UPE Contact Name       | PLR Reference Returned | Polling Behavior                                                      |
-|------------------------|------------------------|--------------------------------------------------------------------- |
-| Quick Processing       | XEPLR0000000001        | Returns 404 for first 3 polls (6 seconds), then returns 200 success    |
-| Medium Processing      | XEPLR0000000002        | Returns 404 for first 8 polls (16 seconds), then returns 200 success   |
-| Timeout Processing     | XEPLR0000000003        | Always returns 500 (server error) - simulates timeout scenario         |
-
-**Option 2: Using Organisation Name (legacy)**
-
+For testing the registration in progress feature, use specific organisation names to trigger different polling behaviors:
 
 | Organisation Name      | PLR Reference Returned | Polling Behavior                                                        |
 |------------------------|------------------------|-------------------------------------------------------------------------|
-| Quick Processing Corp  | XEPLR0000000001        | Returns 404 for first 3 polls (6 seconds), then returns 200 success    |
-| Medium Processing Corp | XEPLR0000000002        | Returns 404 for first 8 polls (16 seconds), then returns 200 success   |
-| Timeout Processing Corp| XEPLR0000000003        | Always returns 500 (server error) - simulates timeout scenario           |
+| Quick Processing Corp  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
+| Medium Processing Corp | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
+| Timeout Processing Corp| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
 
 #### Happy Path:
 
@@ -376,12 +363,12 @@ Retrieves the Subscription details for the specific plrReference
 
 | plrReference    | Status Code | Status                | Description                                                                                          |
 |-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
-| XEPLR0000000001 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 3 polls, then 200 success                     |
-| XEPLR0000000002 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 8 polls, then 200 success                     |
-| XEPLR0000000003 | 500         | SERVER_ERROR | Registration in progress test - Always returns 500 (timeout scenario)                             |
+| XEPLR0000000001 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 3 polls, then 200 success                     |
+| XEPLR0000000002 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 8 polls, then 200 success                     |
+| XEPLR0000000003 | 422         | CANNOT_COMPLETE_REQUEST | Registration in progress test - Always returns 422 (timeout scenario)                             |
 | XEPLR0123456400 | 400         | BAD_REQUEST           | Submission has not passed validation. Invalid plrReference.                                          |
 | XEPLR0123456404 | 404         | NOT_FOUND             | Submission has not passed validation. Record not found.                                              |
-| XEPLR0123456422 | 404         | NOT_FOUND  | Subscription not found.               |
+| XEPLR0123456422 | 422         | CANNOT_COMPLETE_REQUEST  | Request could not be completed because the subscription is being created or amended.               |
 | XEPLR0123456500 | 500         | INTERNAL_SERVER_ERROR | Internal Server error.                                                                               |
 | XEPLR0123456503 | 503         | SERVICE_UNAVAILABLE   | Dependent systems are currently not responding.                                                      |
 | XEPLR5555555555 | 200         | OK                    | Returns read success response with accountStatus.inactive set to true.                               |

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ For testing the registration in progress feature, you can use either UPE contact
 
 **Option 1: Using UPE Contact Name**
 
-Set the `upeContactName` field to one of these values:
+Enter one of these values in the "Contact Name" field during registration:
 
 | UPE Contact Name       | PLR Reference Returned | Polling Behavior                                                      |
 |------------------------|------------------------|--------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ For testing the registration in progress feature, use specific organisation name
 
 | Organisation Name      | PLR Reference Returned | Polling Behavior                                                        |
 |------------------------|------------------------|-------------------------------------------------------------------------|
-| Quick Processing Corp  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
-| Medium Processing Corp | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
-| Timeout Processing Corp| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
+| Quick Processing Corp  | XEPLR0000000001        | Returns 404 for first 3 polls (6 seconds), then returns 200 success    |
+| Medium Processing Corp | XEPLR0000000002        | Returns 404 for first 8 polls (16 seconds), then returns 200 success   |
+| Timeout Processing Corp| XEPLR0000000003        | Always returns 500 (server error) - simulates timeout scenario           |
 
 #### Happy Path:
 
@@ -363,12 +363,12 @@ Retrieves the Subscription details for the specific plrReference
 
 | plrReference    | Status Code | Status                | Description                                                                                          |
 |-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
-| XEPLR0000000001 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 3 polls, then 200 success                     |
-| XEPLR0000000002 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 8 polls, then 200 success                     |
-| XEPLR0000000003 | 422         | CANNOT_COMPLETE_REQUEST | Registration in progress test - Always returns 422 (timeout scenario)                             |
+| XEPLR0000000001 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 3 polls, then 200 success                     |
+| XEPLR0000000002 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 8 polls, then 200 success                     |
+| XEPLR0000000003 | 500         | SERVER_ERROR | Registration in progress test - Always returns 500 (timeout scenario)                             |
 | XEPLR0123456400 | 400         | BAD_REQUEST           | Submission has not passed validation. Invalid plrReference.                                          |
 | XEPLR0123456404 | 404         | NOT_FOUND             | Submission has not passed validation. Record not found.                                              |
-| XEPLR0123456422 | 422         | CANNOT_COMPLETE_REQUEST  | Request could not be completed because the subscription is being created or amended.               |
+| XEPLR0123456422 | 404         | NOT_FOUND  | Subscription not found.               |
 | XEPLR0123456500 | 500         | INTERNAL_SERVER_ERROR | Internal Server error.                                                                               |
 | XEPLR0123456503 | 503         | SERVICE_UNAVAILABLE   | Dependent systems are currently not responding.                                                      |
 | XEPLR5555555555 | 200         | OK                    | Returns read success response with accountStatus.inactive set to true.                               |

--- a/README.md
+++ b/README.md
@@ -239,7 +239,20 @@ Creates a Subscription request
 
 #### Registration In Progress Test Data
 
-For testing the registration in progress feature, use specific organisation names to trigger different polling behaviors:
+For testing the registration in progress feature, you can use either UPE contact names or organisation names to trigger different polling behaviors:
+
+**Option 1: Using UPE Contact Name**
+
+Set the `upeContactName` field to one of these values:
+
+| UPE Contact Name       | PLR Reference Returned | Polling Behavior                                                      |
+|------------------------|------------------------|--------------------------------------------------------------------- |
+| Quick Processing       | XEPLR0000000001        | Returns 404 for first 3 polls (6 seconds), then returns 200 success    |
+| Medium Processing      | XEPLR0000000002        | Returns 404 for first 8 polls (16 seconds), then returns 200 success   |
+| Timeout Processing     | XEPLR0000000003        | Always returns 500 (server error) - simulates timeout scenario         |
+
+**Option 2: Using Organisation Name (legacy)**
+
 
 | Organisation Name      | PLR Reference Returned | Polling Behavior                                                        |
 |------------------------|------------------------|-------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ By default, the service runs locally on port **10052**
 
 To use test-only route locally, run the below:
 
-`sbt 'run -Dplay.http.router=testOnlyDoNotUseInAppConf.Routes 10052'`
+`sbt '
+'`
 
 ### Using Service Manager
 
@@ -243,9 +244,9 @@ For testing the registration in progress feature, use specific organisation name
 
 | Test Trigger                           | PLR Reference Returned | Polling Behavior                                                        |
 |----------------------------------------|------------------------|-------------------------------------------------------------------------|
-| Organisation Name: "Quick Processing Corp" OR UPE Contact Name: "Quick Processing"  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
-| Organisation Name: "Medium Processing Corp" OR UPE Contact Name: "Medium Processing" | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
-| Organisation Name: "Timeout Processing Corp" OR UPE Contact Name: "Timeout Processing"| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
+|  UPE Contact Name: "Quick Processing" OR "Quick Processing Corp"  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
+| UPE Contact Name: "Medium Processing" OR "Medium Processing Corp" | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
+| UPE Contact Name: "Timeout Processing" OR "Timeout Processing Corp"| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
 
 **Note**: The UPE contact name is read from `primaryContactDetails.name` in the request body. If both organisation name and UPE contact name match test triggers, UPE contact name takes precedence.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ By default, the service runs locally on port **10052**
 
 To use test-only route locally, run the below:
 
-`sbt '
-'`
+`sbt 'run -Dplay.http.router=testOnlyDoNotUseInAppConf.Routes 10052'`
 
 ### Using Service Manager
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ For testing the registration in progress feature, use specific organisation name
 |----------------------------------------|------------------------|-------------------------------------------------------------------------|
 |  UPE Contact Name: "Quick Processing" OR "Quick Processing Corp"  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
 | UPE Contact Name: "Medium Processing" OR "Medium Processing Corp" | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
-| UPE Contact Name: "Timeout Processing" OR "Timeout Processing Corp"| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
 
 **Note**: The UPE contact name is read from `primaryContactDetails.name` in the request body. If both organisation name and UPE contact name match test triggers, UPE contact name takes precedence.
 
@@ -366,8 +365,7 @@ Retrieves the Subscription details for the specific plrReference
 | plrReference    | Status Code | Status                | Description                                                                                          |
 |-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
 | XEPLR0000000001 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 3 polls, then 200 success                     |
-| XEPLR0000000002 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 8 polls, then 200 success                     |
-| XEPLR0000000003 | 422         | CANNOT_COMPLETE_REQUEST | Registration in progress test - Always returns 422 (timeout scenario)                             |
+| XEPLR0000000002 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 8 polls, then 200 success                     |                           |
 | XEPLR0123456400 | 400         | BAD_REQUEST           | Submission has not passed validation. Invalid plrReference.                                          |
 | XEPLR0123456404 | 404         | NOT_FOUND             | Submission has not passed validation. Record not found.                                              |
 | XEPLR0123456422 | 422         | CANNOT_COMPLETE_REQUEST  | Request could not be completed because the subscription is being created or amended.               |
@@ -561,8 +559,7 @@ Reads the Subscription details and caches them for the specific PLR reference an
 | plrReference    | Status Code | Status                | Description                                                                                          |
 |-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
 | XEPLR0000000001 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 3 polls, then 200 success                     |
-| XEPLR0000000002 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 8 polls, then 200 success                     |
-| XEPLR0000000003 | 500         | INTERNAL_SERVER_ERROR | Registration in progress test - Always returns 500 (timeout scenario)                              |
+| XEPLR0000000002 | 404/200     | VARIABLE              | Registration in progress test - Returns 404 for first 8 polls, then 200 success                     |                             |
 | Any other PLR   | 200         | OK                    | Returns read success response for any other valid PLR reference                                      |
 
 #### Happy Path:
@@ -576,7 +573,6 @@ The response format is identical to the `GET /pillar2/subscription/:plrReference
 This endpoint uses the same polling logic as the `retrieveSubscription` endpoint for the special test PLR references:
 - **XEPLR0000000001**: Quick processing scenario - succeeds after 3 attempts
 - **XEPLR0000000002**: Medium processing scenario - succeeds after 8 attempts  
-- **XEPLR0000000003**: Timeout scenario - always returns server error
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ POST /pillar2/subscription
 
 Creates a Subscription request
 
+#### Registration In Progress Test Data
+
+For testing the registration in progress feature, use specific organisation names to trigger different polling behaviors:
+
+| Organisation Name      | PLR Reference Returned | Polling Behavior                                                        |
+|------------------------|------------------------|-------------------------------------------------------------------------|
+| Quick Processing Corp  | XEPLR0000000001        | Returns 422 for first 3 polls (6 seconds), then returns 200 success    |
+| Medium Processing Corp | XEPLR0000000002        | Returns 422 for first 8 polls (16 seconds), then returns 200 success   |
+| Timeout Processing Corp| XEPLR0000000003        | Always returns 422 (processing) - simulates timeout scenario           |
+
 #### Happy Path:
 
 To trigger the happy path, ensure you provide a valid request body
@@ -353,6 +363,9 @@ Retrieves the Subscription details for the specific plrReference
 
 | plrReference    | Status Code | Status                | Description                                                                                          |
 |-----------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------|
+| XEPLR0000000001 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 3 polls, then 200 success                     |
+| XEPLR0000000002 | 422/200     | VARIABLE              | Registration in progress test - Returns 422 for first 8 polls, then 200 success                     |
+| XEPLR0000000003 | 422         | CANNOT_COMPLETE_REQUEST | Registration in progress test - Always returns 422 (timeout scenario)                             |
 | XEPLR0123456400 | 400         | BAD_REQUEST           | Submission has not passed validation. Invalid plrReference.                                          |
 | XEPLR0123456404 | 404         | NOT_FOUND             | Submission has not passed validation. Record not found.                                              |
 | XEPLR0123456422 | 422         | CANNOT_COMPLETE_REQUEST  | Request could not be completed because the subscription is being created or amended.               |

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/EnrolmentStoreProxyController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/EnrolmentStoreProxyController.scala
@@ -26,13 +26,14 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import javax.inject.Inject
 
 class EnrolmentStoreProxyController @Inject() (cc: ControllerComponents, authFilter: AuthActionFilter) extends BackendController(cc) {
-  private val badService      = "HMRC-PILLAR2-ORG~PLRID~XEPLR0444444400"
-  private val plrServiceEmpty = "HMRC-PILLAR2-ORG~PLRID~XMPLR0012345674"
+  private val badService       = "HMRC-PILLAR2-ORG~PLRID~XEPLR0444444400"
+  private val plrServiceEmpty  = "HMRC-PILLAR2-ORG~PLRID~XMPLR0012345674"
+  private val plrServiceEmpty2 = "HMRC-PILLAR2-ORG~PLRID~XEPLR0000000002"
 
   def status(serviceName: String): Action[AnyContent] = (Action andThen authFilter) { _ =>
     serviceName match {
       case `badService` => NoContent
-      case `plrServiceEmpty` =>
+      case `plrServiceEmpty` | `plrServiceEmpty2` =>
         val path = "/resources/groupsES1/enrolment-response-with-no-groupid.json"
         Ok(resourceAsString(path).get)
       case _ =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -142,7 +142,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         case "XEPLR0123456404" =>
           Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
         case "XEPLR0123456422" =>
-          Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
+          Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
         case "XEPLR0123456500" =>
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
         case "XEPLR0123456503" =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -97,7 +97,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Quick Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 3) {
-            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
+            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
           } else {
             Future.successful(
               Ok(
@@ -113,7 +113,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Medium Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 8) {
-            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
+            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
           } else {
             Future.successful(
               Ok(
@@ -126,7 +126,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
 
         case "XEPLR0000000003" => // Timeout scenario - always returns 422 (processing)
           logger.info(s"Timeout Processing Corp - Always processing for $plrReference")
-          Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
+          Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
 
         // Existing test cases
         case "XEPLR0123456400" =>
@@ -134,7 +134,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         case "XEPLR0123456404" =>
           Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
         case "XEPLR0123456422" =>
-          Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
+          Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
         case "XEPLR0123456500" =>
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
         case "XEPLR0123456503" =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -100,7 +100,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Quick Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 3) {
-            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
+            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
           } else {
             Future.successful(
               Ok(
@@ -116,7 +116,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Medium Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 8) {
-            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
+            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
           } else {
             Future.successful(
               Ok(
@@ -209,7 +209,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Quick Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 3) {
-            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
+            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
           } else {
             Future.successful(
               Ok(
@@ -225,7 +225,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
           pollCounters(plrReference) = count
           logger.info(s"Medium Processing Corp - Poll attempt $count for $plrReference")
           if (count <= 8) {
-            Future.successful(NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get))
+            Future.successful(UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get))
           } else {
             Future.successful(
               Ok(

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -43,11 +43,11 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         val upeContactName   = input.upeContactName.getOrElse("")
 
         (upeContactName, organisationName, safeId) match {
-          case ("Quick Processing", _, _) =>
+          case ("Quick Processing", _, _) | ("Quick Processing Corp", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
-          case ("Medium Processing", _, _) =>
+          case ("Medium Processing", _, _) | ("Medium Processing Corp", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
-          case ("Timeout Processing", _, _) =>
+          case ("Timeout Processing", _, _) | ("Timeout Processing Corp", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
 
           case (_, "Quick Processing Corp", _) =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -52,8 +52,8 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
           case ("Timeout Processing", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
-          
-          // Original company name test cases - return specific PLR references based on company name  
+
+          // Original company name test cases - return specific PLR references based on company name
           case (_, "Quick Processing Corp", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
           case (_, "Medium Processing Corp", _) =>

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -41,45 +41,55 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
       case Some(input) =>
         val organisationName = input.organisationName
         val safeId           = input.safeId
+        val upeContactName   = input.upeContactName.getOrElse("")
 
-        (organisationName, safeId) match {
-          // Registration in progress test cases - return specific PLR references based on company name
-          case ("Quick Processing Corp", _) =>
+        // Check UPE contact details first, then fall back to company name/safeId
+        (upeContactName, organisationName, safeId) match {
+          // Registration in progress test cases - return specific PLR references based on UPE contact details
+          case ("Quick Processing", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
-          case ("Medium Processing Corp", _) =>
+          case ("Medium Processing", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
-          case ("Timeout Processing Corp", _) =>
+          case ("Timeout Processing", _, _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
+          
+          // Original company name test cases - return specific PLR references based on company name  
+          case (_, "Quick Processing Corp", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
+          case (_, "Medium Processing Corp", _) =>
+            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
+          case (_, "Timeout Processing Corp", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
 
           // Existing test cases
-          case ("duplicateSub", _) =>
+          case (_, "duplicateSub", _) =>
             Conflict(resourceAsString("/resources/error/subscription/Conflict.json").get)
-          case ("unprocessableSub", _) =>
+          case (_, "unprocessableSub", _) =>
             UnprocessableEntity(resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
-          case ("subServerError", _) =>
+          case (_, "subServerError", _) =>
             ServiceUnavailable(resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get)
-          case ("subRecordNotFound", _) =>
+          case (_, "subRecordNotFound", _) =>
             NotFound(resourceAsString("/resources/error/subscription/NotFound.json").get)
-          case ("subReqNotProcessed", _) =>
+          case (_, "subReqNotProcessed", _) =>
             UnprocessableEntity(resourceAsString("/resources/error/subscription/UnprocessableEntity.json").get)
-          case ("subInvalidRequest", _) =>
+          case (_, "subInvalidRequest", _) =>
             BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
 
-          case ("XE0000123456400", _) =>
+          case (_, "XE0000123456400", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456400")).get)
-          case ("XE0000123456404", _) =>
+          case (_, "XE0000123456404", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456404")).get)
-          case ("XE0000123456422", _) =>
+          case (_, "XE0000123456422", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456422")).get)
-          case ("XE0000123456500", _) =>
+          case (_, "XE0000123456500", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456500")).get)
-          case ("XE0000123456503", _) =>
+          case (_, "XE0000123456503", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XE0000123456503")).get)
-          case (_, "XE0000123456789") =>
+          case (_, _, "XE0000123456789") =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345671")).get)
-          case ("XMPLR0009999999", _) =>
+          case (_, "XMPLR0009999999", _) =>
             Conflict(resourceAsString("/resources/error/subscription/Conflict.json").map(replacePillar2Id(_, "XMPLR0009999999")).get)
-          case (_, _) =>
+          case (_, _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XMPLR0012345674")).get)
           case _ => BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get)
         }

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -47,8 +47,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
           case ("Medium Processing", _, _) | ("Medium Processing Corp", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
-          case ("Timeout Processing", _, _) | ("Timeout Processing Corp", _, _) =>
-            Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
 
           case (_, "Quick Processing Corp", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
@@ -128,10 +126,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
               )
             )
           }
-
-        case "XEPLR0000000003" =>
-          logger.info(s"Timeout Processing Corp - Always processing for $plrReference")
-          Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
 
         case "XEPLR0123456400" =>
           Future.successful(BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get))

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -31,7 +31,6 @@ import scala.concurrent.Future
 
 class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: AuthActionFilter) extends BackendController(cc) with Logging {
 
- 
   private val pollCounters = scala.collection.mutable.Map[String, Int]()
 
   def createSubscription: Action[JsValue] = (Action(parse.json) andThen authFilter) { implicit request =>
@@ -43,7 +42,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
         val safeId           = input.safeId
         val upeContactName   = input.upeContactName.getOrElse("")
 
-      
         (upeContactName, organisationName, safeId) match {
           case ("Quick Processing", _, _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000001")).get)
@@ -58,7 +56,6 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000002")).get)
           case (_, "Timeout Processing Corp", _) =>
             Created(resourceAsString("/resources/subscription/SuccessResponse.json").map(replacePillar2Id(_, "XEPLR0000000003")).get)
-
 
           case (_, "duplicateSub", _) =>
             Conflict(resourceAsString("/resources/error/subscription/Conflict.json").get)
@@ -100,7 +97,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
       logger.info(s"retrieveSubscription Request received \n $plrReference \n")
       plrReference match {
 
-        case "XEPLR0000000001" => 
+        case "XEPLR0000000001" =>
           val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
           pollCounters(plrReference) = count
           logger.info(s"Quick Processing Corp - Poll attempt $count for $plrReference")
@@ -116,7 +113,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             )
           }
 
-        case "XEPLR0000000002" => 
+        case "XEPLR0000000002" =>
           val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
           pollCounters(plrReference) = count
           logger.info(s"Medium Processing Corp - Poll attempt $count for $plrReference")
@@ -132,11 +129,10 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             )
           }
 
-        case "XEPLR0000000003" => 
+        case "XEPLR0000000003" =>
           logger.info(s"Timeout Processing Corp - Always processing for $plrReference")
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
 
-   
         case "XEPLR0123456400" =>
           Future.successful(BadRequest(resourceAsString("/resources/error/subscription/BadRequest.json").get))
         case "XEPLR0123456404" =>
@@ -213,8 +209,8 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
     (Action andThen authFilter).async {
       logger.info(s"readSubscriptionAndCache Request received for id: $id, plrReference: $plrReference")
       plrReference match {
-      
-        case "XEPLR0000000001" => 
+
+        case "XEPLR0000000001" =>
           val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
           pollCounters(plrReference) = count
           logger.info(s"Quick Processing Corp - Poll attempt $count for $plrReference")
@@ -230,7 +226,7 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             )
           }
 
-        case "XEPLR0000000002" =>  
+        case "XEPLR0000000002" =>
           val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
           pollCounters(plrReference) = count
           logger.info(s"Medium Processing Corp - Poll attempt $count for $plrReference")
@@ -246,11 +242,10 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             )
           }
 
-        case "XEPLR0000000003" => 
+        case "XEPLR0000000003" =>
           logger.info(s"Timeout Processing Corp - Always processing for $plrReference")
           Future.successful(InternalServerError(resourceAsString("/resources/error/subscription/ServerError.json").get))
 
-   
         case _ =>
           resourceAsString("/resources/subscription/ReadSuccessResponse.json") match {
             case Some(responseTemplate) =>

--- a/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.pillar2stubs.models
 import play.api.libs.json.{Reads, __}
 
 case class Subscription(
-  safeId: String, 
+  safeId:           String,
   organisationName: String,
-  upeContactName: Option[String],
-  upeCapturePhone: Option[String]
+  upeContactName:   Option[String],
+  upeCapturePhone:  Option[String]
 )
 
 object Subscription {

--- a/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
@@ -32,7 +32,7 @@ object Subscription {
     (
       (__ \ "upeDetails" \ "safeId").read[String] and
         (__ \ "upeDetails" \ "organisationName").read[String] and
-        (__ \ "upeContactName").readNullable[String] and
+        (__ \ "primaryContactDetails" \ "name").readNullable[String] and
         (__ \ "upeCapturePhone").readNullable[String]
     )(Subscription.apply _)
   }

--- a/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/models/Subscription.scala
@@ -18,7 +18,12 @@ package uk.gov.hmrc.pillar2stubs.models
 
 import play.api.libs.json.{Reads, __}
 
-case class Subscription(safeId: String, organisationName: String)
+case class Subscription(
+  safeId: String, 
+  organisationName: String,
+  upeContactName: Option[String],
+  upeCapturePhone: Option[String]
+)
 
 object Subscription {
 
@@ -26,7 +31,9 @@ object Subscription {
     import play.api.libs.functional.syntax._
     (
       (__ \ "upeDetails" \ "safeId").read[String] and
-        (__ \ "upeDetails" \ "organisationName").read[String]
+        (__ \ "upeDetails" \ "organisationName").read[String] and
+        (__ \ "upeContactName").readNullable[String] and
+        (__ \ "upeCapturePhone").readNullable[String]
     )(Subscription.apply _)
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,6 +3,7 @@
 POST          /registration/02.00.00/organisation                                          uk.gov.hmrc.pillar2stubs.controllers.RegisterWithoutIdController.registerWithoutId
 POST          /pillar2/subscription                                                        uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.createSubscription
 GET           /pillar2/subscription/:plrReference                                          uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.retrieveSubscription(plrReference: String)
+GET           /pillar2/subscription/read-subscription/:id/:plrReference                   uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.readSubscriptionAndCache(id: String, plrReference: String)
 PUT           /pillar2/subscription                                                        uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.amendSubscription
 
 

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
@@ -290,7 +290,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe BAD_REQUEST
       }
 
-      // Registration in progress test cases - UPE contact name scenarios
       "must return CREATED with XEPLR0000000001 for UPE contact name Quick Processing" in {
         val input: String =
           """{
@@ -377,7 +376,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         responseBody should include("XEPLR0000000002")
       }
 
-      // Registration in progress test cases - Company name scenarios
       "must return CREATED with XEPLR0000000001 for organisation name Quick Processing Corp" in {
         val input: String =
           """{
@@ -522,19 +520,18 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe SERVICE_UNAVAILABLE
       }
 
-      // Registration in progress test cases for polling behavior
-      "must return NOT_FOUND initially for XEPLR0000000001 (Quick Processing)" in {
+      "must return UNPROCESSABLE_ENTITY initially for XEPLR0000000001 (Quick Processing)" in {
         val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000001").url).withHeaders(authHeader)
         val result  = route(app, request).value
 
-        status(result) shouldBe NOT_FOUND
+        status(result) shouldBe UNPROCESSABLE_ENTITY
       }
 
-      "must return NOT_FOUND initially for XEPLR0000000002 (Medium Processing)" in {
+      "must return UNPROCESSABLE_ENTITY initially for XEPLR0000000002 (Medium Processing)" in {
         val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000002").url).withHeaders(authHeader)
         val result  = route(app, request).value
 
-        status(result) shouldBe NOT_FOUND
+        status(result) shouldBe UNPROCESSABLE_ENTITY
       }
 
     }
@@ -550,18 +547,18 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe OK
       }
 
-      "must return NOT_FOUND initially for XEPLR0000000001 (Quick Processing)" in {
+      "must return UNPROCESSABLE_ENTITY initially for XEPLR0000000001 (Quick Processing)" in {
         val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000001").withHeaders(authHeader)
         val result  = route(app, request).value
 
-        status(result) shouldBe NOT_FOUND
+        status(result) shouldBe UNPROCESSABLE_ENTITY
       }
 
-      "must return NOT_FOUND initially for XEPLR0000000002 (Medium Processing)" in {
+      "must return UNPROCESSABLE_ENTITY initially for XEPLR0000000002 (Medium Processing)" in {
         val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000002").withHeaders(authHeader)
         val result  = route(app, request).value
 
-        status(result) shouldBe NOT_FOUND
+        status(result) shouldBe UNPROCESSABLE_ENTITY
       }
 
     }

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
@@ -377,49 +377,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         responseBody should include("XEPLR0000000002")
       }
 
-      "must return CREATED with XEPLR0000000003 for UPE contact name Timeout Processing" in {
-        val input: String =
-          """{
-            | 			"upeDetails": {
-            | 				"safeId": "XE6666666666666",
-            | 				"organisationName": "Test Corp",
-            | 				"registrationDate": "2023-09-28",
-            | 				"domesticOnly": false,
-            | 				"filingMember": false
-            | 			},
-            | 			"accountingPeriod": {
-            | 				"startDate": "2024-12-31",
-            | 				"endDate": "2025-12-12"
-            | 			},
-            | 			"upeCorrespAddressDetails": {
-            | 				"addressLine1": "10 High Street",
-            | 				"addressLine2": "Egham",
-            | 				"addressLine3": "Surrey",
-            | 				"addressLine4": "South East England",
-            | 				"countryCode": "GB"
-            | 			},
-            | 			"primaryContactDetails": {
-            | 				"name": "Timeout Processing",
-            | 				"emailAddress": "Test@test.com"
-            | 			},
-            | 			"filingMemberDetails": {
-            | 				"safeId": "XE6666666666666",
-            | 				"organisationName": "Test"
-            | 			}
-            | 	}
-            |
-            |""".stripMargin
-
-        val json:       JsValue          = Json.parse(input)
-        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
-        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
-        val result  = route(app, request).value
-
-        status(result) shouldBe CREATED
-        val responseBody = contentAsString(result)
-        responseBody should include("XEPLR0000000003")
-      }
-
       // Registration in progress test cases - Company name scenarios
       "must return CREATED with XEPLR0000000001 for organisation name Quick Processing Corp" in {
         val input: String =
@@ -507,49 +464,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         responseBody should include("XEPLR0000000002")
       }
 
-      "must return CREATED with XEPLR0000000003 for organisation name Timeout Processing Corp" in {
-        val input: String =
-          """{
-            | 			"upeDetails": {
-            | 				"safeId": "XE6666666666666",
-            | 				"organisationName": "Timeout Processing Corp",
-            | 				"registrationDate": "2023-09-28",
-            | 				"domesticOnly": false,
-            | 				"filingMember": false
-            | 			},
-            | 			"accountingPeriod": {
-            | 				"startDate": "2024-12-31",
-            | 				"endDate": "2025-12-12"
-            | 			},
-            | 			"upeCorrespAddressDetails": {
-            | 				"addressLine1": "10 High Street",
-            | 				"addressLine2": "Egham",
-            | 				"addressLine3": "Surrey",
-            | 				"addressLine4": "South East England",
-            | 				"countryCode": "GB"
-            | 			},
-            | 			"primaryContactDetails": {
-            | 				"name": "Test Contact",
-            | 				"emailAddress": "Test@test.com"
-            | 			},
-            | 			"filingMemberDetails": {
-            | 				"safeId": "XE6666666666666",
-            | 				"organisationName": "Test"
-            | 			}
-            | 	}
-            |
-            |""".stripMargin
-
-        val json:       JsValue          = Json.parse(input)
-        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
-        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
-        val result  = route(app, request).value
-
-        status(result) shouldBe CREATED
-        val responseBody = contentAsString(result)
-        responseBody should include("XEPLR0000000003")
-      }
-
     }
 
   }
@@ -623,12 +537,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe NOT_FOUND
       }
 
-      "must return INTERNAL_SERVER_ERROR for XEPLR0000000003 (Timeout Processing)" in {
-        val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000003").url).withHeaders(authHeader)
-        val result  = route(app, request).value
-
-        status(result) shouldBe INTERNAL_SERVER_ERROR
-      }
     }
 
     "readSubscriptionAndCache" - {
@@ -656,12 +564,6 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe NOT_FOUND
       }
 
-      "must return INTERNAL_SERVER_ERROR for XEPLR0000000003 (Timeout Processing)" in {
-        val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000003").withHeaders(authHeader)
-        val result  = route(app, request).value
-
-        status(result) shouldBe INTERNAL_SERVER_ERROR
-      }
     }
 
   }

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
@@ -290,6 +290,266 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe BAD_REQUEST
       }
 
+      // Registration in progress test cases - UPE contact name scenarios
+      "must return CREATED with XEPLR0000000001 for UPE contact name Quick Processing" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Quick Processing",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000001")
+      }
+
+      "must return CREATED with XEPLR0000000002 for UPE contact name Medium Processing" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Medium Processing",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000002")
+      }
+
+      "must return CREATED with XEPLR0000000003 for UPE contact name Timeout Processing" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Timeout Processing",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000003")
+      }
+
+      // Registration in progress test cases - Company name scenarios
+      "must return CREATED with XEPLR0000000001 for organisation name Quick Processing Corp" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Quick Processing Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Test Contact",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000001")
+      }
+
+      "must return CREATED with XEPLR0000000002 for organisation name Medium Processing Corp" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Medium Processing Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Test Contact",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000002")
+      }
+
+      "must return CREATED with XEPLR0000000003 for organisation name Timeout Processing Corp" in {
+        val input: String =
+          """{
+            | 			"upeDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Timeout Processing Corp",
+            | 				"registrationDate": "2023-09-28",
+            | 				"domesticOnly": false,
+            | 				"filingMember": false
+            | 			},
+            | 			"accountingPeriod": {
+            | 				"startDate": "2024-12-31",
+            | 				"endDate": "2025-12-12"
+            | 			},
+            | 			"upeCorrespAddressDetails": {
+            | 				"addressLine1": "10 High Street",
+            | 				"addressLine2": "Egham",
+            | 				"addressLine3": "Surrey",
+            | 				"addressLine4": "South East England",
+            | 				"countryCode": "GB"
+            | 			},
+            | 			"primaryContactDetails": {
+            | 				"name": "Test Contact",
+            | 				"emailAddress": "Test@test.com"
+            | 			},
+            | 			"filingMemberDetails": {
+            | 				"safeId": "XE6666666666666",
+            | 				"organisationName": "Test"
+            | 			}
+            | 	}
+            |
+            |""".stripMargin
+
+        val json:       JsValue          = Json.parse(input)
+        val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+        val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url).withBody(json).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe CREATED
+        val responseBody = contentAsString(result)
+        responseBody should include("XEPLR0000000003")
+      }
+
     }
 
   }
@@ -346,6 +606,61 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         val result  = route(app, request).value
 
         status(result) shouldBe SERVICE_UNAVAILABLE
+      }
+
+      // Registration in progress test cases for polling behavior
+      "must return NOT_FOUND initially for XEPLR0000000001 (Quick Processing)" in {
+        val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000001").url).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe NOT_FOUND
+      }
+
+      "must return NOT_FOUND initially for XEPLR0000000002 (Medium Processing)" in {
+        val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000002").url).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe NOT_FOUND
+      }
+
+      "must return INTERNAL_SERVER_ERROR for XEPLR0000000003 (Timeout Processing)" in {
+        val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscription("XEPLR0000000003").url).withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "readSubscriptionAndCache" - {
+
+      val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+
+      "must return OK response for valid id and plrReference" in {
+        val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/validPlr").withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe OK
+      }
+
+      "must return NOT_FOUND initially for XEPLR0000000001 (Quick Processing)" in {
+        val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000001").withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe NOT_FOUND
+      }
+
+      "must return NOT_FOUND initially for XEPLR0000000002 (Medium Processing)" in {
+        val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000002").withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe NOT_FOUND
+      }
+
+      "must return INTERNAL_SERVER_ERROR for XEPLR0000000003 (Timeout Processing)" in {
+        val request = FakeRequest(GET, "/pillar2/subscription/read-subscription/testId/XEPLR0000000003").withHeaders(authHeader)
+        val result  = route(app, request).value
+
+        status(result) shouldBe INTERNAL_SERVER_ERROR
       }
     }
 


### PR DESCRIPTION
Added in-memory poll counter to track polling attempts per PLR reference
Implemented three test scenarios for registration in progress behavior:
Quick Processing Corp (XEPLR0000000001): Returns 422 for first 3 polls (~6 seconds), then returns 200 success
Medium Processing Corp (XEPLR0000000002): Returns 422 for first 8 polls (~16 seconds), then returns 200 success
Timeout Processing Corp (XEPLR0000000003): Always returns 422 to simulate timeout scenarios
Enhanced retrieveSubscription endpoint to handle polling behavior based on PLR reference
Added logging for tracking poll attempts