### PR TITLE
PIL-2858 - Add dynamic stateful v2 subscription stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The Pillar2 stubs service provides stubs for the GRS systems to mock the respons
     * [Amend Existing Subscription](#amend-existing-subscription)
       * [Happy Path](#happy-path-4)
     * [Amend Existing Subscription V2](#amend-existing-subscription-v2)
+      * [Dynamic V2 Subscriptions](#dynamic-v2-subscriptions)
+    * [Reset Dynamic V2 Subscriptions](#reset-dynamic-v2-subscriptions)
     * [Retrieve Enrolment Store Response](#retrieve-enrolment-store-response)
       * [Happy Path](#happy-path-5)
         * [Enrolment Store Response with groupID](#enrolment-store-response-with-groupid)
@@ -709,6 +711,9 @@ The following plrReferences return special accounting period configurations for 
 | XEPLR7777777777 | Returns subscription with a **micro period** (short period: 2024-01-31 to 2024-02-15). |
 | XEPLR2856000001 | Returns subscription for a **recently registered group with a micro initial period** — 3 periods from Jan 2024, first period is 6 months (2024-01-01 to 2024-06-30), all periods fully amendable. |
 | XEPLR2856000002 | Returns subscription for an **older group with anniversary-date-aligned periods and a locked current period end date** — 3 full 12-month periods from Sep 2021, with `canAmendEndDate: false` on the most recent period. |
+| XEPLR0000000010 | **Dynamic** -- 3 periods with mixed `canAmend*` flags. State updates when amended via V2. See [Dynamic V2 Subscriptions](#dynamic-v2-subscriptions). |
+| XEPLR0000000011 | **Dynamic** -- 2 fully amendable periods. State updates when amended via V2. See [Dynamic V2 Subscriptions](#dynamic-v2-subscriptions). |
+| XEPLR0000000012 | **Dynamic** -- 1 fully amendable period. State updates when amended via V2. See [Dynamic V2 Subscriptions](#dynamic-v2-subscriptions). |
 | Any other valid | Returns subscription with a single standard accounting period.              |
 
 #### Happy Path
@@ -812,7 +817,47 @@ Example Request Body:
 | "503"                      | 503         | SERVICE_UNAVAILABLE   | Triggers a Service Unavailable error.                                                   |
 | "10 seconds"               | 200         | OK                    | Returns a success response after a 10-second delay.                                     |
 | "timeout"                  | 200         | OK                    | Returns a success response after a 30-second delay (will induce a client-side timeout). |
-| Any other value            | 200         | OK                    | Returns a success response.                                                             |
+| Any other value            | 200         | OK                    | Returns a success response. If the PLR reference is a dynamic ID, the accounting periods are updated in the store. |
+
+#### Dynamic V2 Subscriptions
+
+A subset of PLR IDs have **stateful** behaviour: amending them via `PUT /pillar2/subscription/v2` updates the accounting periods returned by subsequent `GET /pillar2/subscription/v2/:plrReference` calls. This allows end-to-end testing of the multi-period amend flow without a real ETMP backend.
+
+**Dynamic PLR IDs and initial data:**
+
+| plrReference    | Initial periods | canAmendStartDate / canAmendEndDate |
+|-----------------|-----------------|-------------------------------------|
+| XEPLR0000000010 | 2024-01-01 to 2024-12-31, 2025-01-01 to 2025-12-31, 2026-01-01 to 2026-12-31 | false/true, true/true, true/false |
+| XEPLR0000000011 | 2024-01-01 to 2024-12-31, 2025-01-01 to 2025-12-31 | true/true, true/true |
+| XEPLR0000000012 | 2025-01-01 to 2025-12-31 | true/true |
+
+**Amendment behaviour (ETMP simulation):**
+
+When a V2 amend request is received with `amendAccountingPeriod: true` and the PLR reference matches one of the dynamic IDs:
+
+1. The `originalAccountingPeriods` from the request are matched against the stored periods by start/end date.
+2. Matched periods are removed.
+3. The `newAccountingPeriod` is added.
+4. If the new period does not cover the full date range of the removed periods, **micro-periods** are created to fill the gaps (before and/or after the new period).
+5. All resulting periods are sorted by start date with `canAmendStartDate` and `canAmendEndDate` set to `true`.
+
+**Example:** Amending `XEPLR0000000011` by replacing both periods (2024-01-01 to 2025-12-31) with a new period of 2024-06-01 to 2025-05-31 will produce three periods:
+- 2024-01-01 to 2024-05-31 (micro-period, gap before)
+- 2024-06-01 to 2025-05-31 (new period)
+- 2025-06-01 to 2025-12-31 (micro-period, gap after)
+
+Error-triggering behaviour via `primaryContactDetails.name` (400, 422, etc.) still takes precedence over dynamic updates.
+
+---
+
+### Reset Dynamic V2 Subscriptions
+
+**Endpoint**: `POST /pillar2/subscription/v2/reset`
+
+**Description**: Resets all dynamic V2 subscription data back to its initial seeded state. Useful for test setup to ensure a clean starting point.
+
+- Response status: `200`
+- Response body: `Dynamic subscriptions reset to initial state`
 
 ---
 

--- a/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionController.scala
@@ -23,7 +23,7 @@ import play.api.mvc.Results.Status
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.{readSuccessResponse, readSuccessResponseV2}
 import uk.gov.hmrc.pillar2stubs.controllers.actions.AuthActionFilter
-import uk.gov.hmrc.pillar2stubs.models.{AmendSubscriptionSuccess, AmendSubscriptionSuccessV2, Subscription}
+import uk.gov.hmrc.pillar2stubs.models.{AccountingPeriodV2, AmendSubscriptionSuccess, AmendSubscriptionSuccessV2, Subscription}
 import uk.gov.hmrc.pillar2stubs.utils.ResourceHelper.resourceAsString
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.bootstrap.http.ErrorResponse
@@ -35,7 +35,10 @@ import scala.concurrent.Future
 
 class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: AuthActionFilter) extends BackendController(cc) with Logging {
 
-  private val pollCounters = scala.collection.mutable.Map[String, Int]()
+  private val pollCounters         = scala.collection.mutable.Map[String, Int]()
+  private val dynamicSubscriptions = scala.collection.mutable.Map[String, JsObject]()
+  seedDynamicData()
+
   def now:         ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
   def currentYear: Int           = now.getYear
 
@@ -228,6 +231,8 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
             Future.successful(Ok(resourceAsString("/resources/subscription/AmendSuccessResponse.json").getOrElse("Success response")))
 
           case _ =>
+            val plrRef = subscriptionResponse.upeDetails.plrReference
+            if dynamicSubscriptions.contains(plrRef) then applyAmendment(plrRef, subscriptionResponse.accountingPeriod)
             logger.info(s"AmendSubscriptionV2 Request received \n ${request.body} \n")
             Future.successful(Ok(resourceAsString("/resources/subscription/AmendSuccessResponse.json").getOrElse("Success response")))
         }
@@ -250,6 +255,107 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
   private def removeSecondaryContact(response: String): String =
     (__ \ "success" \ "secondaryContactDetails").prune(Json.parse(response).as[JsObject]).get.toString
 
+  private def makePeriod(start: String, end: String, due: String, canAmendStart: Boolean, canAmendEnd: Boolean): JsObject =
+    Json.obj(
+      "startDate"         -> start,
+      "endDate"           -> end,
+      "dueDate"           -> due,
+      "canAmendStartDate" -> canAmendStart,
+      "canAmendEndDate"   -> canAmendEnd
+    )
+
+  private def buildDynamicSubscription(periods: Seq[JsObject]): JsObject = {
+    val base    = Json.parse(readSuccessResponseV2).as[JsObject]
+    val success = (base \ "success").as[JsObject] ++ Json.obj("accountingPeriod" -> JsArray(periods))
+    Json.obj("success" -> success)
+  }
+
+  private def seedDynamicData(): Unit = {
+    dynamicSubscriptions("XEPLR0000000010") = buildDynamicSubscription(
+      Seq(
+        makePeriod("2024-01-01", "2024-12-31", "2025-06-01", canAmendStart = false, canAmendEnd = true),
+        makePeriod("2025-01-01", "2025-12-31", "2026-06-01", canAmendStart = true, canAmendEnd = true),
+        makePeriod("2026-01-01", "2026-12-31", "2027-06-01", canAmendStart = true, canAmendEnd = false)
+      )
+    )
+    dynamicSubscriptions("XEPLR0000000011") = buildDynamicSubscription(
+      Seq(
+        makePeriod("2024-01-01", "2024-12-31", "2025-06-01", canAmendStart = true, canAmendEnd = true),
+        makePeriod("2025-01-01", "2025-12-31", "2026-06-01", canAmendStart = true, canAmendEnd = true)
+      )
+    )
+    dynamicSubscriptions("XEPLR0000000012") = buildDynamicSubscription(
+      Seq(
+        makePeriod("2025-01-01", "2025-12-31", "2026-06-01", canAmendStart = true, canAmendEnd = true)
+      )
+    )
+  }
+
+  private def applyAmendment(plrRef: String, ap: AccountingPeriodV2): Unit =
+    (ap.amendAccountingPeriod, ap.originalAccountingPeriods, ap.newAccountingPeriod) match {
+      case (true, Some(originals), Some(newPeriod)) =>
+        val stored         = dynamicSubscriptions(plrRef)
+        val success        = (stored \ "success").as[JsObject]
+        val currentPeriods = (success \ "accountingPeriod").as[Seq[JsObject]]
+
+        val originalDatePairs    = originals.map(o => (o.taxObligationStartDate, o.taxObligationEndDate)).toSet
+        val (matched, remaining) = currentPeriods.partition { p =>
+          val start = LocalDate.parse((p \ "startDate").as[String])
+          val end   = LocalDate.parse((p \ "endDate").as[String])
+          originalDatePairs.contains((start, end))
+        }
+
+        if matched.nonEmpty then
+          val matchedStarts = matched.map(p => LocalDate.parse((p \ "startDate").as[String]))
+          val matchedEnds   = matched.map(p => LocalDate.parse((p \ "endDate").as[String]))
+          val minStart      = matchedStarts.min
+          val maxEnd        = matchedEnds.max
+
+          val newStart = newPeriod.updateObligationStartDate
+          val newEnd   = newPeriod.updateObligationEndDate
+
+          val newPeriodObj = makePeriod(
+            newStart.toString,
+            newEnd.toString,
+            newEnd.plusMonths(6).toString,
+            canAmendStart = true,
+            canAmendEnd = true
+          )
+
+          val gapBefore = Option.when(newStart.isAfter(minStart))(
+            makePeriod(
+              minStart.toString,
+              newStart.minusDays(1).toString,
+              newStart.minusDays(1).plusMonths(6).toString,
+              canAmendStart = true,
+              canAmendEnd = true
+            )
+          )
+
+          val gapAfter = Option.when(newEnd.isBefore(maxEnd))(
+            makePeriod(
+              newEnd.plusDays(1).toString,
+              maxEnd.toString,
+              maxEnd.plusMonths(6).toString,
+              canAmendStart = true,
+              canAmendEnd = true
+            )
+          )
+
+          val resultPeriods = (remaining :+ newPeriodObj) ++ gapBefore.toSeq ++ gapAfter.toSeq
+          val sorted        = resultPeriods.sortBy(p => LocalDate.parse((p \ "startDate").as[String]))
+
+          val updatedSuccess = success ++ Json.obj("accountingPeriod" -> JsArray(sorted))
+          dynamicSubscriptions(plrRef) = Json.obj("success" -> updatedSuccess)
+
+      case _ => ()
+    }
+
+  def resetDynamicSubscriptions: Action[AnyContent] = Action {
+    seedDynamicData()
+    Ok("Dynamic subscriptions reset to initial state")
+  }
+
   def retrieveSubscriptionV2(plrReference: String): Action[AnyContent] =
     (Action andThen authFilter) {
       logger.info(s"retrieveSubscriptionV2 Request received \n $plrReference \n")
@@ -264,56 +370,60 @@ class SubscriptionController @Inject() (cc: ControllerComponents, authFilter: Au
       if status == OK then Ok(unwrapSuccess(body)) else Status(status)(body)
     }
 
-  private def subscriptionResponseV2(plrReference: String): (Int, String) = plrReference match {
+  private def subscriptionResponseV2(plrReference: String): (Int, String) =
+    dynamicSubscriptions
+      .get(plrReference)
+      .map(stored => (OK, Json.stringify(stored)))
+      .getOrElse(plrReference match {
 
-    case ref @ "XEPLR0000000001" =>
-      val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
-      pollCounters(plrReference) = count
-      logger.info(s"Quick Processing Corp V2 - Poll attempt $count for $plrReference")
-      if count <= 3 then (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
-      else (OK, readSuccessResponseV2WithRef(ref))
+        case ref @ "XEPLR0000000001" =>
+          val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
+          pollCounters(plrReference) = count
+          logger.info(s"Quick Processing Corp V2 - Poll attempt $count for $plrReference")
+          if count <= 3 then (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
+          else (OK, readSuccessResponseV2WithRef(ref))
 
-    case ref @ "XEPLR0000000002" =>
-      val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
-      pollCounters(plrReference) = count
-      logger.info(s"Medium Processing Corp V2 - Poll attempt $count for $plrReference")
-      if count <= 8 then (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
-      else (OK, readSuccessResponseV2WithRef(ref))
+        case ref @ "XEPLR0000000002" =>
+          val count = pollCounters.getOrElseUpdate(plrReference, 0) + 1
+          pollCounters(plrReference) = count
+          logger.info(s"Medium Processing Corp V2 - Poll attempt $count for $plrReference")
+          if count <= 8 then (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
+          else (OK, readSuccessResponseV2WithRef(ref))
 
-    case "XEPLR0123456400" => (BAD_REQUEST, resourceAsString("/resources/error/subscription/BadRequest.json").get)
-    case "XEPLR0123456404" => (NOT_FOUND, resourceAsString("/resources/error/subscription/NotFound.json").get)
-    case "XEPLR0123456422" => (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
-    case "XEPLR0123456500" => (INTERNAL_SERVER_ERROR, resourceAsString("/resources/error/subscription/ServerError.json").get)
-    case "XEPLR0123456502" => (502, resourceAsString("/resources/error/subscription/BadGateway.json").get)
-    case "XEPLR0123456503" => (SERVICE_UNAVAILABLE, resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get)
+        case "XEPLR0123456400" => (BAD_REQUEST, resourceAsString("/resources/error/subscription/BadRequest.json").get)
+        case "XEPLR0123456404" => (NOT_FOUND, resourceAsString("/resources/error/subscription/NotFound.json").get)
+        case "XEPLR0123456422" => (UNPROCESSABLE_ENTITY, resourceAsString("/resources/error/subscription/CannotCompleteRequest.json").get)
+        case "XEPLR0123456500" => (INTERNAL_SERVER_ERROR, resourceAsString("/resources/error/subscription/ServerError.json").get)
+        case "XEPLR0123456502" => (502, resourceAsString("/resources/error/subscription/BadGateway.json").get)
+        case "XEPLR0123456503" => (SERVICE_UNAVAILABLE, resourceAsString("/resources/error/subscription/ServiceUnavailable.json").get)
 
-    case ref @ "XEPLR5555555555" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
-    case "XEPLR5555551111"       => (OK, replaceDate(readSuccessResponseV2, LocalDate.now().toString))
-    case ref @ "XEPLR6666666666" =>
-      (OK, readSuccessResponseV2WithRef(ref).replace("\"registrationDate\": \"2024-01-31\"", "\"registrationDate\": \"2011-01-31\""))
-    case ref @ "XEPLR1066196600" => (OK, readSuccessResponseV2WithRef(ref).replace("\"domesticOnly\": false", "\"domesticOnly\": true"))
-    case ref @ "XEPLR1066196602" => (OK, readSuccessResponseV2WithRef(ref).replace("\"domesticOnly\": false", "\"domesticOnly\": true"))
-    case ref @ "XEPLR2000000109" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
-    case ref @ "XEPLR2000000110" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
-    case ref @ "XEPLR2000000111" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
-    case ref @ "XEPLR2000000112" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
-    case ref @ "XEPLR2000000200" => (OK, removeSecondaryContact(readSuccessResponseV2WithRef(ref)))
+        case ref @ "XEPLR5555555555" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
+        case "XEPLR5555551111"       => (OK, replaceDate(readSuccessResponseV2, LocalDate.now().toString))
+        case ref @ "XEPLR6666666666" =>
+          (OK, readSuccessResponseV2WithRef(ref).replace("\"registrationDate\": \"2024-01-31\"", "\"registrationDate\": \"2011-01-31\""))
+        case ref @ "XEPLR1066196600" => (OK, readSuccessResponseV2WithRef(ref).replace("\"domesticOnly\": false", "\"domesticOnly\": true"))
+        case ref @ "XEPLR1066196602" => (OK, readSuccessResponseV2WithRef(ref).replace("\"domesticOnly\": false", "\"domesticOnly\": true"))
+        case ref @ "XEPLR2000000109" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
+        case ref @ "XEPLR2000000110" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
+        case ref @ "XEPLR2000000111" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
+        case ref @ "XEPLR2000000112" => (OK, makeInactive(readSuccessResponseV2WithRef(ref)))
+        case ref @ "XEPLR2000000200" => (OK, removeSecondaryContact(readSuccessResponseV2WithRef(ref)))
 
-    case "XEPLR9999999999" => (OK, readSuccessResponseV2WithEmptyPeriods)
-    case "XEPLR8888888888" => (OK, readSuccessResponseV2WithMultiplePeriods)
-    case "XEPLR7777777777" => (OK, readSuccessResponseV2WithMicroPeriod)
-    case "XEPLR2856000001" => (OK, readSuccessResponseV2WithMicroInitialPeriod)
-    case "XEPLR2856000002" => (OK, readSuccessResponseV2WithLockedCurrentPeriodEndDate)
+        case "XEPLR9999999999" => (OK, readSuccessResponseV2WithEmptyPeriods)
+        case "XEPLR8888888888" => (OK, readSuccessResponseV2WithMultiplePeriods)
+        case "XEPLR7777777777" => (OK, readSuccessResponseV2WithMicroPeriod)
+        case "XEPLR2856000001" => (OK, readSuccessResponseV2WithMicroInitialPeriod)
+        case "XEPLR2856000002" => (OK, readSuccessResponseV2WithLockedCurrentPeriodEndDate)
 
-    case _ =>
-      (
-        OK,
-        readSuccessResponseV2WithRef("plrReference")
-          .replace("\"startDate\": \"2024-01-06\"", s"\"startDate\": \"${LocalDate.of(currentYear - 1, 1, 1)}\"")
-          .replace("\"endDate\": \"2025-04-06\"", s"\"endDate\": \"${LocalDate.of(currentYear - 1, 12, 31)}\"")
-          .replace("\"dueDate\": \"2024-04-06\"", s"\"dueDate\": \"${LocalDate.now()}\"")
-      )
-  }
+        case _ =>
+          (
+            OK,
+            readSuccessResponseV2WithRef("plrReference")
+              .replace("\"startDate\": \"2024-01-06\"", s"\"startDate\": \"${LocalDate.of(currentYear - 1, 1, 1)}\"")
+              .replace("\"endDate\": \"2025-04-06\"", s"\"endDate\": \"${LocalDate.of(currentYear - 1, 12, 31)}\"")
+              .replace("\"dueDate\": \"2024-04-06\"", s"\"dueDate\": \"${LocalDate.now()}\"")
+          )
+      })
 
   private def readSuccessResponseV2WithRef(reference: String): String = replacePillar2Id(readSuccessResponseV2, reference)
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,6 +8,7 @@ GET           /report-pillar2-top-up-taxes/subscription/read-subscription/:plrRe
 GET           /report-pillar2-top-up-taxes/subscription/read-subscription/:id/:plrReference uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.retrieveSubscriptionCache(id: String, plrReference: String)
 PUT           /pillar2/subscription                                                        uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.amendSubscription
 PUT           /pillar2/subscription/v2                                                     uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.amendSubscriptionV2
+POST          /pillar2/subscription/v2/reset                                               uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.resetDynamicSubscriptions
 
 # V2 Subscription Routes
 GET           /pillar2/subscription/v2/:plrReference                                          uk.gov.hmrc.pillar2stubs.controllers.SubscriptionController.retrieveSubscriptionV2(plrReference: String)

--- a/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2stubs/controllers/SubscriptionControllerSpec.scala
@@ -16,16 +16,31 @@
 
 package uk.gov.hmrc.pillar2stubs.controllers
 
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inspectors, OptionValues}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsArray, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderNames
 
-class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with Inspectors {
+class SubscriptionControllerSpec
+    extends AnyFreeSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with OptionValues
+    with Inspectors
+    with BeforeAndAfterEach {
+
+  private val authHeader: (String, String) = HeaderNames.authorisation -> "token"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val request = FakeRequest(POST, routes.SubscriptionController.resetDynamicSubscriptions.url)
+    route(app, request).value: Unit
+  }
 
   "POST " - {
     "createSubscription" - {
@@ -919,6 +934,278 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
       }
     }
 
+  }
+
+  "Dynamic V2 subscriptions" - {
+
+    "must return seeded initial periods for XEPLR0000000010" in {
+      val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000010").url).withHeaders(authHeader)
+      val result  = route(app, request).value
+
+      status(result) shouldBe OK
+      val periods = (contentAsJson(result) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length shouldBe 3
+
+      (periods(0) \ "startDate").as[String]          shouldBe "2024-01-01"
+      (periods(0) \ "endDate").as[String]            shouldBe "2024-12-31"
+      (periods(0) \ "canAmendStartDate").as[Boolean] shouldBe false
+      (periods(0) \ "canAmendEndDate").as[Boolean]   shouldBe true
+
+      (periods(1) \ "startDate").as[String]          shouldBe "2025-01-01"
+      (periods(1) \ "endDate").as[String]            shouldBe "2025-12-31"
+      (periods(1) \ "canAmendStartDate").as[Boolean] shouldBe true
+      (periods(1) \ "canAmendEndDate").as[Boolean]   shouldBe true
+
+      (periods(2) \ "startDate").as[String]          shouldBe "2026-01-01"
+      (periods(2) \ "endDate").as[String]            shouldBe "2026-12-31"
+      (periods(2) \ "canAmendStartDate").as[Boolean] shouldBe true
+      (periods(2) \ "canAmendEndDate").as[Boolean]   shouldBe false
+    }
+
+    "must return seeded initial periods for XEPLR0000000011" in {
+      val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000011").url).withHeaders(authHeader)
+      val result  = route(app, request).value
+
+      status(result) shouldBe OK
+      val periods = (contentAsJson(result) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length                        shouldBe 2
+      (periods(0) \ "startDate").as[String] shouldBe "2024-01-01"
+      (periods(1) \ "startDate").as[String] shouldBe "2025-01-01"
+    }
+
+    "must return seeded initial period for XEPLR0000000012" in {
+      val request = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000012").url).withHeaders(authHeader)
+      val result  = route(app, request).value
+
+      status(result) shouldBe OK
+      val periods = (contentAsJson(result) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length                        shouldBe 1
+      (periods(0) \ "startDate").as[String] shouldBe "2025-01-01"
+      (periods(0) \ "endDate").as[String]   shouldBe "2025-12-31"
+    }
+
+    "must update periods when amend v2 is called for a dynamic ID" in {
+      val amendJson = Json.parse("""{
+          |  "upeDetails": {
+          |    "plrReference": "XEPLR0000000011",
+          |    "customerIdentification1": "12345678",
+          |    "customerIdentification2": "12345678",
+          |    "organisationName": "Test Org",
+          |    "registrationDate": "2024-01-31",
+          |    "domesticOnly": false,
+          |    "filingMember": false
+          |  },
+          |  "upeCorrespAddressDetails": {
+          |    "addressLine1": "1 High Street",
+          |    "addressLine2": "Egham",
+          |    "addressLine3": "Wycombe",
+          |    "addressLine4": "Surrey",
+          |    "postCode": "HP13 6TT",
+          |    "countryCode": "GB"
+          |  },
+          |  "primaryContactDetails": {
+          |    "name": "Test Contact",
+          |    "telephone": "0115 9700 700",
+          |    "emailAddress": "test@example.com"
+          |  },
+          |  "accountingPeriod": {
+          |    "amendAccountingPeriod": true,
+          |    "originalAccountingPeriods": [
+          |      { "taxObligationStartDate": "2024-01-01", "taxObligationEndDate": "2024-12-31" },
+          |      { "taxObligationStartDate": "2025-01-01", "taxObligationEndDate": "2025-12-31" }
+          |    ],
+          |    "newAccountingPeriod": {
+          |      "updateObligationStartDate": "2024-01-01",
+          |      "updateObligationEndDate": "2025-12-31"
+          |    }
+          |  }
+          |}""".stripMargin)
+
+      val amendRequest = FakeRequest(PUT, routes.SubscriptionController.amendSubscriptionV2.url).withHeaders(authHeader).withBody(amendJson)
+      val amendResult  = route(app, amendRequest).value
+      status(amendResult) shouldBe OK
+
+      val readRequest = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000011").url).withHeaders(authHeader)
+      val readResult  = route(app, readRequest).value
+
+      status(readResult) shouldBe OK
+      val periods = (contentAsJson(readResult) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length                                 shouldBe 1
+      (periods(0) \ "startDate").as[String]          shouldBe "2024-01-01"
+      (periods(0) \ "endDate").as[String]            shouldBe "2025-12-31"
+      (periods(0) \ "canAmendStartDate").as[Boolean] shouldBe true
+      (periods(0) \ "canAmendEndDate").as[Boolean]   shouldBe true
+    }
+
+    "must create micro-periods when new period does not cover full original range" in {
+      val amendJson = Json.parse("""{
+          |  "upeDetails": {
+          |    "plrReference": "XEPLR0000000011",
+          |    "customerIdentification1": "12345678",
+          |    "customerIdentification2": "12345678",
+          |    "organisationName": "Test Org",
+          |    "registrationDate": "2024-01-31",
+          |    "domesticOnly": false,
+          |    "filingMember": false
+          |  },
+          |  "upeCorrespAddressDetails": {
+          |    "addressLine1": "1 High Street",
+          |    "addressLine2": "Egham",
+          |    "addressLine3": "Wycombe",
+          |    "addressLine4": "Surrey",
+          |    "postCode": "HP13 6TT",
+          |    "countryCode": "GB"
+          |  },
+          |  "primaryContactDetails": {
+          |    "name": "Test Contact",
+          |    "telephone": "0115 9700 700",
+          |    "emailAddress": "test@example.com"
+          |  },
+          |  "accountingPeriod": {
+          |    "amendAccountingPeriod": true,
+          |    "originalAccountingPeriods": [
+          |      { "taxObligationStartDate": "2024-01-01", "taxObligationEndDate": "2024-12-31" },
+          |      { "taxObligationStartDate": "2025-01-01", "taxObligationEndDate": "2025-12-31" }
+          |    ],
+          |    "newAccountingPeriod": {
+          |      "updateObligationStartDate": "2024-06-01",
+          |      "updateObligationEndDate": "2025-05-31"
+          |    }
+          |  }
+          |}""".stripMargin)
+
+      val amendRequest = FakeRequest(PUT, routes.SubscriptionController.amendSubscriptionV2.url).withHeaders(authHeader).withBody(amendJson)
+      val amendResult  = route(app, amendRequest).value
+      status(amendResult) shouldBe OK
+
+      val readRequest = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000011").url).withHeaders(authHeader)
+      val readResult  = route(app, readRequest).value
+
+      status(readResult) shouldBe OK
+      val periods = (contentAsJson(readResult) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length shouldBe 3
+
+      (periods(0) \ "startDate").as[String] shouldBe "2024-01-01"
+      (periods(0) \ "endDate").as[String]   shouldBe "2024-05-31"
+
+      (periods(1) \ "startDate").as[String] shouldBe "2024-06-01"
+      (periods(1) \ "endDate").as[String]   shouldBe "2025-05-31"
+
+      (periods(2) \ "startDate").as[String] shouldBe "2025-06-01"
+      (periods(2) \ "endDate").as[String]   shouldBe "2025-12-31"
+    }
+
+    "must not affect non-dynamic IDs when amending a dynamic ID" in {
+      val amendJson = Json.parse("""{
+          |  "upeDetails": {
+          |    "plrReference": "XEPLR0000000012",
+          |    "customerIdentification1": "12345678",
+          |    "customerIdentification2": "12345678",
+          |    "organisationName": "Test Org",
+          |    "registrationDate": "2024-01-31",
+          |    "domesticOnly": false,
+          |    "filingMember": false
+          |  },
+          |  "upeCorrespAddressDetails": {
+          |    "addressLine1": "1 High Street",
+          |    "addressLine2": "Egham",
+          |    "addressLine3": "Wycombe",
+          |    "addressLine4": "Surrey",
+          |    "postCode": "HP13 6TT",
+          |    "countryCode": "GB"
+          |  },
+          |  "primaryContactDetails": {
+          |    "name": "Test Contact",
+          |    "telephone": "0115 9700 700",
+          |    "emailAddress": "test@example.com"
+          |  },
+          |  "accountingPeriod": {
+          |    "amendAccountingPeriod": true,
+          |    "originalAccountingPeriods": [
+          |      { "taxObligationStartDate": "2025-01-01", "taxObligationEndDate": "2025-12-31" }
+          |    ],
+          |    "newAccountingPeriod": {
+          |      "updateObligationStartDate": "2025-01-01",
+          |      "updateObligationEndDate": "2025-06-30"
+          |    }
+          |  }
+          |}""".stripMargin)
+
+      val amendRequest = FakeRequest(PUT, routes.SubscriptionController.amendSubscriptionV2.url).withHeaders(authHeader).withBody(amendJson)
+      status(route(app, amendRequest).value) shouldBe OK
+
+      val staticRequest = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR8888888888").url).withHeaders(authHeader)
+      val staticResult  = route(app, staticRequest).value
+      status(staticResult) shouldBe OK
+
+      val periods = (contentAsJson(staticResult) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length                        shouldBe 2
+      (periods(0) \ "startDate").as[String] shouldBe "2024-01-01"
+      (periods(1) \ "startDate").as[String] shouldBe "2025-01-01"
+    }
+
+    "must restore initial state after reset" in {
+      val amendJson = Json.parse("""{
+          |  "upeDetails": {
+          |    "plrReference": "XEPLR0000000012",
+          |    "customerIdentification1": "12345678",
+          |    "customerIdentification2": "12345678",
+          |    "organisationName": "Test Org",
+          |    "registrationDate": "2024-01-31",
+          |    "domesticOnly": false,
+          |    "filingMember": false
+          |  },
+          |  "upeCorrespAddressDetails": {
+          |    "addressLine1": "1 High Street",
+          |    "addressLine2": "Egham",
+          |    "addressLine3": "Wycombe",
+          |    "addressLine4": "Surrey",
+          |    "postCode": "HP13 6TT",
+          |    "countryCode": "GB"
+          |  },
+          |  "primaryContactDetails": {
+          |    "name": "Test Contact",
+          |    "telephone": "0115 9700 700",
+          |    "emailAddress": "test@example.com"
+          |  },
+          |  "accountingPeriod": {
+          |    "amendAccountingPeriod": true,
+          |    "originalAccountingPeriods": [
+          |      { "taxObligationStartDate": "2025-01-01", "taxObligationEndDate": "2025-12-31" }
+          |    ],
+          |    "newAccountingPeriod": {
+          |      "updateObligationStartDate": "2025-03-01",
+          |      "updateObligationEndDate": "2025-09-30"
+          |    }
+          |  }
+          |}""".stripMargin)
+
+      val amendRequest = FakeRequest(PUT, routes.SubscriptionController.amendSubscriptionV2.url).withHeaders(authHeader).withBody(amendJson)
+      status(route(app, amendRequest).value) shouldBe OK
+
+      val resetRequest = FakeRequest(POST, routes.SubscriptionController.resetDynamicSubscriptions.url)
+      val resetResult  = route(app, resetRequest).value
+      status(resetResult) shouldBe OK
+
+      val readRequest = FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionV2("XEPLR0000000012").url).withHeaders(authHeader)
+      val readResult  = route(app, readRequest).value
+
+      status(readResult) shouldBe OK
+      val periods = (contentAsJson(readResult) \ "success" \ "accountingPeriod").as[JsArray].value
+      periods.length                        shouldBe 1
+      (periods(0) \ "startDate").as[String] shouldBe "2025-01-01"
+      (periods(0) \ "endDate").as[String]   shouldBe "2025-12-31"
+    }
+
+    "must also serve dynamic IDs via the cache endpoint" in {
+      val request =
+        FakeRequest(GET, routes.SubscriptionController.retrieveSubscriptionCacheV2("someId", "XEPLR0000000010").url).withHeaders(authHeader)
+      val result = route(app, request).value
+
+      status(result) shouldBe OK
+      val periods = (contentAsJson(result) \ "accountingPeriod").as[JsArray].value
+      periods.length shouldBe 3
+    }
   }
 
   private def testBothVersions(plrReference: String, expectedStatus: Int, additionalAssertions: JsValue => Unit = _ => ()): Unit = {


### PR DESCRIPTION
## Summary

- Introduces three dynamic PLR IDs (`XEPLR0000000010`, `XEPLR0000000011`, `XEPLR0000000012`) whose accounting period state is held in-memory and updated when amended via `PUT /pillar2/subscription/v2`
- Subsequent `GET /pillar2/subscription/v2/:plrReference` calls for these IDs reflect the amended state, enabling end-to-end testing of the multi-period amend flow
- Applies ETMP-like amendment logic: matched original periods are removed, the new period is inserted, and micro-periods are generated to fill any date gaps before or after the new period
- Adds a `POST /pillar2/subscription/v2/reset` endpoint to restore all dynamic IDs to their initial seeded state between tests
- All existing PLR IDs and v1 endpoints are unaffected