### PR TITLE
PIL-2950 Added integration tests to lint and prePrChecks.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,16 +4,11 @@ style = defaultWithAlign
 maxColumn = 150
 lineEndings = unix
 importSelectors = singleLine
-rewrite.scala3.convertToNewSyntax = true
-
-project {
-  git = true
-}
 
 align = most
 
 align {
-  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":" ]
+  tokens = [{code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":"]
   arrowEnumeratorGenerator = true
   openParenCallSite = false
   openParenDefnSite = false
@@ -33,7 +28,12 @@ newlines {
   sometimesBeforeColonInMethodReturnType = true
 }
 
+project {
+  git = true
+}
+
 rewrite {
+  scala3.convertToNewSyntax = true
   rules = [RedundantBraces, RedundantParens, AsciiSortImports]
   redundantBraces {
     maxLines = 100

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,9 +5,8 @@ maxColumn = 150
 lineEndings = unix
 importSelectors = singleLine
 
-align = most
-
 align {
+  preset = more
   tokens = [{code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":"]
   arrowEnumeratorGenerator = true
   openParenCallSite = false

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version = 3.10.1
-runner.dialect = Scala3
+version = 3.11.1
+runner.dialect = scala3
 style = defaultWithAlign
 maxColumn = 150
 lineEndings = unix

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / scalaVersion := "3.3.6"
 ThisBuild / majorVersion := 0
+ThisBuild / semanticdbEnabled := true
 
 lazy val microservice = Project("pillar2-stubs", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
@@ -25,12 +26,9 @@ lazy val it = project
   )
   .settings(libraryDependencies ++= AppDependencies.it)
 
-ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
-
-addCommandAlias("prePrChecks", "; scalafmtCheckAll; scalafmtSbtCheck; scalafixAll --check")
+addCommandAlias("prePrChecks", "; scalafmtCheckAll; it/scalafmtCheckAll; scalafmtSbtCheck; scalafixAll --check; it/scalafixAll --check")
 addCommandAlias("checkCodeCoverage", "; clean; coverage; test; it/test; coverageReport")
-addCommandAlias("lint", "; scalafmtAll; scalafmtSbt; scalafixAll")
+addCommandAlias("lint", "; scalafmtAll; it/scalafmtAll; scalafmtSbt; it/scalafixAll; scalafixAll")
 
 lazy val compilerSettings = Seq(
   scalacOptions ~= (_.distinct),

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import org.typelevel.scalacoptions.ScalacOptions
-import scoverage.ScoverageKeys
 import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / scalaVersion := "3.3.6"


### PR DESCRIPTION
- Added integration tests to `lint` and `prePrChecks` sbt commands
- Removed semanticdb revision (not needed in Scala 3)